### PR TITLE
distconf - Fallback to last known good value when invalid config

### DIFF
--- a/distconf/distconf.go
+++ b/distconf/distconf.go
@@ -133,8 +133,7 @@ func (c *Config) refresh(key string, configVar configVariable) bool {
 		if v != nil {
 			e = configVar.Update(v)
 			if e != nil {
-				log.WithField("err", e).Warn("Invalid config bytes")
-				continue
+				log.WithField("err", e).Error("Invalid config bytes for " + key)
 			}
 			return dynamicReadersOnPath
 		}


### PR DESCRIPTION
The old code used to continue looking for valid config values
in lower backing stores when an update at a higher level
contained an invalid value. This could cause a simple typo to
revert a distconf variable to another state, which could
be bad(tm). Now on an invalid value the current value of the
config is kept.

Also refactored distconf unit test so that adding a new type
will be easier to test.