### PR TITLE
Add schedexec

### DIFF
--- a/schedexec/schedexec.go
+++ b/schedexec/schedexec.go
@@ -1,0 +1,62 @@
+package schedexec
+
+import (
+	"time"
+
+	"sync"
+	"sync/atomic"
+
+	"github.com/signalfx/golib/timekeeper"
+)
+
+//ScheduledExecutor is an abstraction for running things on a schedule
+type ScheduledExecutor struct {
+	scheduleRate int64
+	TimeKeeper   timekeeper.TimeKeeper
+	closeChan    chan struct{}
+	wg           sync.WaitGroup
+	startedCount uint32
+	runCount     uint32
+}
+
+//NewScheduledExecutor returns a new ScheduledExecutor that will file
+func NewScheduledExecutor(scheduleRate time.Duration) *ScheduledExecutor {
+	return &ScheduledExecutor{
+		scheduleRate: int64(scheduleRate),
+		TimeKeeper:   timekeeper.RealTime{},
+		closeChan:    make(chan struct{}),
+	}
+}
+
+//SetScheduleRate sets the new rate at which runs should run for this ScheduledExecutor
+func (se *ScheduledExecutor) SetScheduleRate(scheduleRate time.Duration) {
+	atomic.StoreInt64(&se.scheduleRate, int64(scheduleRate))
+}
+
+// Start the Scheduled
+func (se *ScheduledExecutor) Start(iterationFunc func() error) error {
+	timer := se.TimeKeeper.NewTimer(time.Duration(atomic.LoadInt64(&se.scheduleRate)))
+	atomic.AddUint32(&se.startedCount, 1)
+	se.wg.Add(1)
+	defer se.wg.Done()
+	for {
+		select {
+		case <-timer.Chan():
+			if err := iterationFunc(); err != nil {
+				return err
+			}
+			timer = se.TimeKeeper.NewTimer(time.Duration(atomic.LoadInt64(&se.scheduleRate)))
+			atomic.AddUint32(&se.runCount, 1)
+		case <-se.closeChan:
+			timer.Stop()
+			return nil
+		}
+	}
+}
+
+//Close stops the ScheduledExecutor
+func (se *ScheduledExecutor) Close() error {
+	close(se.closeChan)
+	se.wg.Wait()
+	return nil
+}

--- a/schedexec/schedexec_test.go
+++ b/schedexec/schedexec_test.go
@@ -1,0 +1,117 @@
+package schedexec
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"runtime"
+	"sync/atomic"
+
+	"github.com/signalfx/golib/timekeeper/timekeepertest"
+	"github.com/stretchr/testify/assert"
+)
+
+type testScheduled struct {
+	calledIteratorCount  int32
+	runOneIterationError error
+}
+
+func (s *testScheduled) runOneIteration() error {
+	atomic.AddInt32(&s.calledIteratorCount, 1)
+	return s.runOneIterationError
+}
+
+func TestNewScheduleExecutor(t *testing.T) {
+	scheduled := &testScheduled{}
+	se := NewScheduledExecutor(time.Second)
+	assert.NotNil(t, se)
+	doneChan := make(chan struct{})
+	var err error
+	go func() {
+		err = se.Start(scheduled.runOneIteration)
+		close(doneChan)
+	}()
+	se.Close()
+	<-doneChan
+	assert.Nil(t, err)
+}
+
+func TestScheduleExecutorTick(t *testing.T) {
+	scheduled := &testScheduled{}
+	se := NewScheduledExecutor(time.Second)
+	stubTime := timekeepertest.NewStubClock(time.Now())
+	se.TimeKeeper = stubTime
+	runChan := make(chan struct{})
+	f := func() error {
+		defer func() { runChan <- struct{}{} }()
+		return scheduled.runOneIteration()
+	}
+
+	doneChan := make(chan struct{})
+	var err error
+	go func() {
+		err = se.Start(f)
+		close(doneChan)
+	}()
+
+	for atomic.LoadUint32(&se.startedCount) == 0 {
+		runtime.Gosched()
+	}
+	stubTime.Incr(time.Second)
+	<-runChan
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&scheduled.calledIteratorCount))
+
+	scheduled.runOneIterationError = errors.New("MOO")
+	for atomic.LoadUint32(&se.runCount) == 0 {
+		runtime.Gosched()
+	}
+	stubTime.Incr(time.Second)
+
+	<-runChan
+	<-doneChan
+	assert.Equal(t, scheduled.runOneIterationError, err)
+
+}
+
+func TestScheduleExecutorUpdateScheduleRate(t *testing.T) {
+	scheduled := &testScheduled{}
+	se := NewScheduledExecutor(time.Second)
+	stubTime := timekeepertest.NewStubClock(time.Now())
+	se.TimeKeeper = stubTime
+	runChan := make(chan struct{})
+	f := func() error {
+		defer func() { runChan <- struct{}{} }()
+		return scheduled.runOneIteration()
+	}
+
+	doneChan := make(chan struct{})
+	var err error
+	go func() {
+		err = se.Start(f)
+		close(doneChan)
+	}()
+
+	for atomic.LoadUint32(&se.startedCount) == 0 {
+		runtime.Gosched()
+	}
+	// make sure we only update the scheduled rate after the initial timer was created
+	se.SetScheduleRate(2 * time.Second)
+
+	stubTime.Incr(time.Second)
+	<-runChan
+	assert.Equal(t, int32(1), atomic.LoadInt32(&scheduled.calledIteratorCount))
+
+	for atomic.LoadUint32(&se.runCount) == 0 {
+		runtime.Gosched()
+	}
+	stubTime.Incr(2 * time.Second)
+	<-runChan
+	assert.Equal(t, int32(2), atomic.LoadInt32(&scheduled.calledIteratorCount))
+
+	se.Close()
+	<-doneChan
+	assert.Equal(t, scheduled.runOneIterationError, err)
+
+}


### PR DESCRIPTION
schedexec is a library for running code on a schedule.
Both fixed and variable rate schedules are supported