### PR TITLE
New errors

### DIFF
--- a/datapoint/datapoint.go
+++ b/datapoint/datapoint.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/signalfx/golib/errors"
 )
 
 // Documentation taken from http://metrics20.org/spec/
@@ -65,7 +67,7 @@ func (dp *Datapoint) UnmarshalJSON(b []byte) error {
 	dec := json.NewDecoder(bytes.NewBuffer(b))
 	dec.UseNumber()
 	if err := dec.Decode(&m); err != nil {
-		return err
+		return errors.Annotatef(err, "JSON decoding of byte array %v failed", b)
 	}
 	switch t := m.Value.(type) {
 	case string:

--- a/distconf/float.go
+++ b/distconf/float.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+
+	"github.com/signalfx/golib/errors"
 )
 
 // FloatWatch is called on any changes to a register integer config variable
@@ -39,7 +41,7 @@ func (c *floatConf) Update(newValue []byte) error {
 	} else {
 		newValueFloat, err := strconv.ParseFloat(string(newValue), 64)
 		if err != nil {
-			return err
+			return errors.Annotatef(err, "unable to parse float %s", newValue)
 		}
 		atomic.StoreUint64(&c.currentVal, math.Float64bits(newValueFloat))
 	}

--- a/distconf/ini.go
+++ b/distconf/ini.go
@@ -1,6 +1,9 @@
 package distconf
 
-import ini "github.com/vaughan0/go-ini"
+import (
+	"github.com/signalfx/golib/errors"
+	ini "github.com/vaughan0/go-ini"
+)
 
 type propertyFileDisco struct {
 	noopCloser
@@ -20,7 +23,7 @@ func (p *propertyFileDisco) Get(key string) ([]byte, error) {
 func Ini(filename string) (Reader, error) {
 	file, err := ini.LoadFile(filename)
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotatef(err, "Unable to open file %s", filename)
 	}
 	return &propertyFileDisco{
 		filename: filename,

--- a/distconf/int.go
+++ b/distconf/int.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+
+	"github.com/signalfx/golib/errors"
 )
 
 // IntWatch is called on any changes to a register integer config variable
@@ -37,7 +39,7 @@ func (c *intConf) Update(newValue []byte) error {
 	} else {
 		newValueInt, err := strconv.ParseInt(string(newValue), 10, 64)
 		if err != nil {
-			return err
+			return errors.Annotatef(err, "Unparsable float %s", string(newValue))
 		}
 		atomic.StoreInt64(&c.currentVal, newValueInt)
 	}

--- a/errors/analyze.go
+++ b/errors/analyze.go
@@ -1,0 +1,65 @@
+package errors
+
+import (
+	"bytes"
+)
+
+// Tail of the error chain: at the end
+func Tail(err error) error {
+	if tail, ok := err.(errLinkedList); ok {
+		return tail.Tail()
+	}
+	if causable, ok := err.(causableError); ok {
+		return causable.Cause()
+	}
+	if hasTail, ok := err.(hasInner); ok {
+		i := hasTail.GetInner()
+		if i == err || i == nil {
+			return err
+		}
+		return Tail(i)
+	}
+	return err
+}
+
+// Next error just below this one, or nil if there is no next error.  Note this may be an error created
+// for you if you used annotations.  As a user, you probably don't want to use this.
+func Next(err error) error {
+	if tail, ok := err.(errLinkedList); ok {
+		return tail.Next()
+	}
+	if u, ok := err.(hasUnderline); ok {
+		return u.Underlying()
+	}
+	if i, ok := err.(hasInner); ok {
+		return i.GetInner()
+	}
+	return nil
+}
+
+// Message is the error string at the Head of the linked list
+func Message(err error) string {
+	if tail, ok := err.(errLinkedList); ok {
+		return tail.Head().Error()
+	}
+	if hasMsg, ok := err.(hasMessage); ok {
+		return hasMsg.Message()
+	}
+	return err.Error()
+}
+
+// Details are an easy to read concat of all the error strings in a chain
+func Details(err error) string {
+	b := bytes.Buffer{}
+	b.WriteByte('[')
+	first := true
+	for ; err != nil; err = Next(err) {
+		if !first {
+			b.WriteString(" | ")
+		}
+		b.WriteString(Message(err))
+		first = false
+	}
+	b.WriteByte(']')
+	return b.String()
+}

--- a/errors/chain.go
+++ b/errors/chain.go
@@ -1,0 +1,39 @@
+package errors
+
+// ErrorChain is a linked list of error pointers that point to a parent above and a child below.
+type ErrorChain struct {
+	// Head of the linked list
+	head error
+	// Next node in the linked list
+	next error
+	// tail node in the linked list
+	tail error
+}
+
+// Tail is the end of the linked list
+func (e *ErrorChain) Tail() error {
+	return e.tail
+}
+
+// Head is the start of the linked list
+func (e *ErrorChain) Head() error {
+	return e.head
+}
+
+// Next is the next node in the linked list
+func (e *ErrorChain) Next() error {
+	return e.next
+}
+
+// Error returns the error string of the tail of the linked list
+func (e *ErrorChain) Error() string {
+	return Cause(e).Error()
+}
+
+type errLinkedList interface {
+	Head() error
+	Next() error
+	Tail() error
+}
+
+var _ errLinkedList = &ErrorChain{}

--- a/errors/compatibility.go
+++ b/errors/compatibility.go
@@ -1,0 +1,52 @@
+package errors
+
+type causableError interface {
+	Cause() error
+}
+
+type hasUnderline interface {
+	Underlying() error
+}
+
+// hasInner is used by dropboxgo
+type hasInner interface {
+	GetInner() error
+}
+
+type hasMessage interface {
+	Message() string
+}
+
+var _ causableError = &ErrorChain{}
+var _ hasUnderline = &ErrorChain{}
+var _ hasMessage = &ErrorChain{}
+
+// Cause lets me simulate errgo
+func (e *ErrorChain) Cause() error {
+	return e.Tail()
+}
+
+// Message lets me simulate errgo
+func (e *ErrorChain) Message() string {
+	return e.Head().Error()
+}
+
+// GetMessage is used by dropbox
+func (e *ErrorChain) GetMessage() string {
+	return e.Head().Error()
+}
+
+// GetInner is used by dropbox
+func (e *ErrorChain) GetInner() error {
+	return e.Head()
+}
+
+// Underlying lets me simulate errgo/facebook
+func (e *ErrorChain) Underlying() error {
+	return e.Next()
+}
+
+// Cause of the original error at the end of the chain
+func Cause(err error) error {
+	return Tail(err)
+}

--- a/errors/compatibility_test.go
+++ b/errors/compatibility_test.go
@@ -1,11 +1,12 @@
 package errors
 
 import (
+	"testing"
+
 	dropboxerrors "github.com/dropbox/godropbox/errors"
 	facebookerrors "github.com/facebookgo/stackerr"
 	jujuerrors "github.com/juju/errors"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestGoDropbox(t *testing.T) {
@@ -26,6 +27,8 @@ func TestGoDropbox(t *testing.T) {
 
 		So(myAnnotation.GetMessage(), ShouldEqual, "I have annotated dropbox error")
 		So(myAnnotation.GetInner().Error(), ShouldEqual, "I have annotated dropbox error")
+
+		So(dropboxerrors.RootError(myAnnotation).Error(), ShouldEqual, Tail(myAnnotation).Error())
 	})
 }
 
@@ -40,6 +43,7 @@ func TestJujuErrors(t *testing.T) {
 		So(Cause(myAnnotation), ShouldEqual, root)
 		So(Details(myAnnotation), ShouldContainSubstring, "juju root error")
 		So(Details(myAnnotation), ShouldContainSubstring, "I have annotated juju error")
+		So(jujuerrors.Cause(myAnnotation), ShouldEqual, Tail(myAnnotation))
 	})
 }
 
@@ -47,12 +51,18 @@ func TestFacebookErrors(t *testing.T) {
 	Convey("When the original error is fb", t, func() {
 		root := facebookerrors.New("fb root error")
 		So(Tail(root), ShouldEqual, root)
-		dropboxWrap := facebookerrors.Wrap(root)
-		So(Tail(dropboxWrap), ShouldEqual, root)
-		myAnnotation := Annotate(dropboxWrap, "I have annotated fb error")
+		fbWrap := facebookerrors.Wrap(root)
+		So(Tail(fbWrap), ShouldEqual, root)
+		myAnnotation := Annotate(fbWrap, "I have annotated fb error")
+
 		So(Tail(myAnnotation), ShouldEqual, root)
 		So(Cause(myAnnotation), ShouldEqual, root)
 		So(Details(myAnnotation), ShouldContainSubstring, "fb root error")
 		So(Details(myAnnotation), ShouldContainSubstring, "I have annotated fb error")
+
+		u := facebookerrors.Underlying(myAnnotation)
+		last := u[len(u)-1]
+		So(last.Error(), ShouldContainSubstring, "fb root error")
+		So(last.Error(), ShouldNotContainSubstring, "I have annotated fb error")
 	})
 }

--- a/errors/compatibility_test.go
+++ b/errors/compatibility_test.go
@@ -1,0 +1,58 @@
+package errors
+
+import (
+	dropboxerrors "github.com/dropbox/godropbox/errors"
+	facebookerrors "github.com/facebookgo/stackerr"
+	jujuerrors "github.com/juju/errors"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestGoDropbox(t *testing.T) {
+	Convey("When the original error is godropbox", t, func() {
+		root := dropboxerrors.New("dropbox root error")
+		So(Tail(root), ShouldEqual, root)
+		dropboxWrap := dropboxerrors.Wrap(root, "Wrapped error")
+		So(Tail(dropboxWrap), ShouldEqual, root)
+		myAnnotation := Annotate(dropboxWrap, "I have annotated dropbox error").(*ErrorChain)
+		So(Tail(myAnnotation), ShouldEqual, root)
+		So(Cause(myAnnotation), ShouldEqual, root)
+		So(Details(myAnnotation), ShouldContainSubstring, "dropbox root error")
+		So(Details(myAnnotation), ShouldContainSubstring, "I have annotated dropbox error")
+
+		So(myAnnotation.Cause(), ShouldEqual, myAnnotation.Tail())
+		So(myAnnotation.Message(), ShouldEqual, myAnnotation.Head().Error())
+		So(myAnnotation.Underlying(), ShouldEqual, myAnnotation.Next())
+
+		So(myAnnotation.GetMessage(), ShouldEqual, "I have annotated dropbox error")
+		So(myAnnotation.GetInner().Error(), ShouldEqual, "I have annotated dropbox error")
+	})
+}
+
+func TestJujuErrors(t *testing.T) {
+	Convey("When the original error is jujuerror", t, func() {
+		root := jujuerrors.New("juju root error")
+		So(Tail(root), ShouldBeNil)
+		dropboxWrap := jujuerrors.Annotate(root, "Wrapped error")
+		So(Tail(dropboxWrap), ShouldEqual, root)
+		myAnnotation := Annotate(dropboxWrap, "I have annotated juju error")
+		So(Tail(myAnnotation), ShouldEqual, root)
+		So(Cause(myAnnotation), ShouldEqual, root)
+		So(Details(myAnnotation), ShouldContainSubstring, "juju root error")
+		So(Details(myAnnotation), ShouldContainSubstring, "I have annotated juju error")
+	})
+}
+
+func TestFacebookErrors(t *testing.T) {
+	Convey("When the original error is fb", t, func() {
+		root := facebookerrors.New("fb root error")
+		So(Tail(root), ShouldEqual, root)
+		dropboxWrap := facebookerrors.Wrap(root)
+		So(Tail(dropboxWrap), ShouldEqual, root)
+		myAnnotation := Annotate(dropboxWrap, "I have annotated fb error")
+		So(Tail(myAnnotation), ShouldEqual, root)
+		So(Cause(myAnnotation), ShouldEqual, root)
+		So(Details(myAnnotation), ShouldContainSubstring, "fb root error")
+		So(Details(myAnnotation), ShouldContainSubstring, "I have annotated fb error")
+	})
+}

--- a/errors/constructors.go
+++ b/errors/constructors.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// New error.  Note returns error rather than *ErrorChain so that it matches errors.New signature
+func New(msg string) error {
+	return errors.New(msg)
+}
+
+// Errorf is fmt.Errorf.  Note returns error rather than *ErrorChain so that it matches fmt.Errorf signature
+func Errorf(msg string, args ...interface{}) error {
+	return fmt.Errorf(msg, args...)
+}
+
+// Annotate adds a new error in the chain that is some extra context about the error
+func Annotate(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	return Wrap(errors.New(msg), err)
+}
+
+// Annotatef adds a new formatf error in the chain that is some extra context about the error
+func Annotatef(err error, msg string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return Wrap(fmt.Errorf(msg, args...), err)
+}
+
+// Wrap a head function giving it the chain defined in next.  Note that wrap may sometimes return head directly
+// if next is nil
+func Wrap(head error, next error) error {
+	if head == nil {
+		// The state head==nil && next!=nil is very strange so I leave it as nil
+		return nil
+	}
+	if next == nil {
+		return head
+	}
+	tail := Tail(next)
+	return &ErrorChain{
+		head: head,
+		next: next,
+		tail: tail,
+	}
+}

--- a/errors/constructors_test.go
+++ b/errors/constructors_test.go
@@ -2,9 +2,10 @@ package errors
 
 import (
 	"errors"
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestBaseError(t *testing.T) {
@@ -54,7 +55,7 @@ func TestNoBaseError(t *testing.T) {
 			So(Details(e), ShouldContainSubstring, "hello world")
 			So(Tail(e).Error(), ShouldEqual, "hello world")
 			So(Next(e), ShouldEqual, nil)
-			})
+		})
 		Convey("Errorf should work", func() {
 			e := Errorf("hello %s", "world")
 			So(e.Error(), ShouldEqual, "hello world")

--- a/errors/constructors_test.go
+++ b/errors/constructors_test.go
@@ -1,0 +1,70 @@
+package errors
+
+import (
+	"errors"
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"testing"
+)
+
+func TestBaseError(t *testing.T) {
+	Convey("When there is a base error", t, func() {
+		baseErr := errors.New("base error")
+		Convey("It should Annotate and show itself", func() {
+			e := Annotate(baseErr, "hello world")
+			So(e.Error(), ShouldEqual, "base error")
+			So(Tail(e).Error(), ShouldEqual, "base error")
+			So(Next(e), ShouldEqual, baseErr)
+			So(Details(e), ShouldContainSubstring, "hello world")
+		})
+		Convey("It should Annotatef and show itself", func() {
+			e := Annotatef(baseErr, "hello %s", "world")
+			So(e.Error(), ShouldEqual, "base error")
+			So(Details(e), ShouldContainSubstring, "hello world")
+			So(Next(e), ShouldEqual, baseErr)
+			So(Tail(e).Error(), ShouldEqual, "base error")
+		})
+		Convey("It should wrap OK", func() {
+			pathErr := &os.PathError{
+				Err: os.ErrNotExist,
+			}
+			So(Wrap(baseErr, nil), ShouldEqual, baseErr)
+			wrappedErr := Wrap(baseErr, pathErr).(*ErrorChain)
+			So(Tail(wrappedErr), ShouldEqual, pathErr)
+			So(Next(wrappedErr), ShouldEqual, pathErr)
+			So(wrappedErr.Error(), ShouldContainSubstring, "file does not exist")
+			So(Details(wrappedErr), ShouldContainSubstring, "base error")
+			So(Details(wrappedErr), ShouldContainSubstring, "file does not exist")
+
+			So(wrappedErr.Head(), ShouldEqual, baseErr)
+			So(wrappedErr.Next(), ShouldEqual, pathErr)
+			So(wrappedErr.Tail(), ShouldEqual, pathErr)
+
+			So(Matches(wrappedErr, os.IsNotExist), ShouldBeTrue)
+		})
+	})
+}
+
+func TestNoBaseError(t *testing.T) {
+	Convey("When there is no base error", t, func() {
+		So(Wrap(nil, nil), ShouldBeNil)
+		Convey("New should work", func() {
+			e := New("hello world")
+			So(e.Error(), ShouldEqual, "hello world")
+			So(Details(e), ShouldContainSubstring, "hello world")
+			So(Tail(e).Error(), ShouldEqual, "hello world")
+			So(Next(e), ShouldEqual, nil)
+			})
+		Convey("Errorf should work", func() {
+			e := Errorf("hello %s", "world")
+			So(e.Error(), ShouldEqual, "hello world")
+			So(Details(e), ShouldContainSubstring, "hello world")
+			So(Tail(e).Error(), ShouldEqual, "hello world")
+			So(Next(e), ShouldEqual, nil)
+		})
+		Convey("Annotates should fail", func() {
+			So(Annotate(nil, "hello world"), ShouldBeNil)
+			So(Annotatef(nil, "hello world"), ShouldBeNil)
+		})
+	})
+}

--- a/errors/log.go
+++ b/errors/log.go
@@ -1,0 +1,38 @@
+package errors
+
+import "fmt"
+
+// Loggable is anything the error loggers can print to
+type Loggable interface {
+	Printf(string, ...interface{})
+}
+
+// LogIfErr will log to l a Printf message if err is not nil
+func LogIfErr(err error, l Loggable, msg string, args ...interface{}) {
+	if err != nil {
+		l.Printf("%s: %s", err.Error(), fmt.Sprintf(msg, args...))
+	}
+}
+
+// DeferLogIfErr will log to l a Printf message if the return value of errCallback is not nil.  Intended use
+// is during a defer function whos return value you don't really care about.
+//
+//  func Thing() error {
+//    f, err := os.Open("/tmp/a")
+//    if err != nil { return Annotate(err, "Cannot open /tmp/a") }
+//    defer DeferLogIfErr(f.Close, log, "Cannot close file %s", "/tmp/a")
+//    // Do something with f
+//  }
+func DeferLogIfErr(errCallback func() error, l Loggable, msg string, args ...interface{}) {
+	err := errCallback()
+	if err != nil {
+		l.Printf("%s: %s", err.Error(), fmt.Sprintf(msg, args...))
+	}
+}
+
+// PanicIfErr is useful if writing shell scripts.  It will panic with a msg if err != nil
+func PanicIfErr(err error, msg string, args ...interface{}) {
+	if err != nil {
+		panic(fmt.Sprintf("%s: %s", err.Error(), fmt.Sprintf(msg, args...)))
+	}
+}

--- a/errors/log_test.go
+++ b/errors/log_test.go
@@ -2,9 +2,10 @@ package errors
 
 import (
 	"bytes"
-	. "github.com/smartystreets/goconvey/convey"
 	"log"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestLogging(t *testing.T) {

--- a/errors/log_test.go
+++ b/errors/log_test.go
@@ -1,0 +1,49 @@
+package errors
+
+import (
+	"bytes"
+	. "github.com/smartystreets/goconvey/convey"
+	"log"
+	"testing"
+)
+
+func TestLogging(t *testing.T) {
+	Convey("If logging", t, func() {
+		buf := bytes.Buffer{}
+		l := log.New(&buf, "", 0)
+		Convey("nil should not log", func() {
+			var e error
+			LogIfErr(e, l, "hello world")
+			So(buf.String(), ShouldEqual, "")
+		})
+		Convey("non nil should log", func() {
+			e := New("err string")
+			LogIfErr(e, l, "hello world")
+			So(buf.String(), ShouldEqual, "err string: hello world\n")
+		})
+		Convey("non nil should log in a defer", func() {
+			f := func() error {
+				return New("defer log here!")
+			}
+			func() {
+				defer DeferLogIfErr(f, l, "called")
+			}()
+			So(buf.String(), ShouldEqual, "defer log here!: called\n")
+		})
+	})
+}
+
+func TestPanics(t *testing.T) {
+	Convey("If panic set", t, func() {
+		Convey("nil should not panic", func() {
+			So(func() {
+				PanicIfErr(nil, "hello world")
+			}, ShouldNotPanic)
+		})
+		Convey("non nil should panic", func() {
+			So(func() {
+				PanicIfErr(New("Err string"), "hello %s", "world")
+			}, ShouldPanicWith, "Err string: hello world")
+		})
+	})
+}

--- a/errors/matcher.go
+++ b/errors/matcher.go
@@ -1,0 +1,29 @@
+package errors
+
+// MatcherFunc is used to match errors
+type MatcherFunc func(error) bool
+
+// Matches should return true if the error matches the wrapped function
+func (m MatcherFunc) Matches(err error) bool {
+	return m(err)
+}
+
+// A Matcher detects if errors match some condition
+type Matcher interface {
+	Matches(err error) bool
+}
+
+// Matches is used to wrap the Cause() and is similar to something like:
+//
+//   f, err := do_something()
+//   if Matches(err, os.IsTimeout) {
+//     // It was a timeout error somewhere...
+//   }
+func Matches(err error, f func(error) bool) bool {
+	return MatchesI(err, MatcherFunc(f))
+}
+
+// MatchesI is like Matches but takes the interface, if you need it.
+func MatchesI(err error, m Matcher) bool {
+	return m.Matches(Cause(err))
+}

--- a/errors/multi.go
+++ b/errors/multi.go
@@ -1,0 +1,39 @@
+package errors
+
+import "strings"
+
+// MultiErr wraps multiple errors into one error string
+type MultiErr struct {
+	errs []error
+}
+
+func (e *MultiErr) Error() string {
+	r := make([]string, 0, len(e.errs))
+	for _, err := range e.errs {
+		r = append(r, err.Error())
+	}
+	return strings.Join(r, " | ")
+}
+
+var _ error = &MultiErr{}
+
+// NewMultiErr will return nil if there are no valid errors in errs, will return the exact, single error
+// if errs only contains a single error, and will otherwise return an instance of MultiErr that wraps all
+// the errors at once.
+func NewMultiErr(errs []error) error {
+	retErrs := make([]error, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			retErrs = append(retErrs, err)
+		}
+	}
+	if len(retErrs) == 0 {
+		return nil
+	}
+	if len(retErrs) == 1 {
+		return retErrs[0]
+	}
+	return &MultiErr{
+		errs: retErrs,
+	}
+}

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -1,8 +1,9 @@
 package errors
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNilMulti(t *testing.T) {

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestNilMulti(t *testing.T) {
+	Convey("For multierr", t, func() {
+		Convey("nil should be nil", func() {
+			So(NewMultiErr(nil), ShouldBeNil)
+			So(NewMultiErr([]error{}), ShouldBeNil)
+			So(NewMultiErr([]error{nil, nil}), ShouldBeNil)
+		})
+		Convey("nil should be filtered", func() {
+			e1 := New("e1")
+			So(NewMultiErr([]error{e1}), ShouldEqual, e1)
+			So(NewMultiErr([]error{e1, nil}), ShouldEqual, e1)
+		})
+		Convey("multi should work", func() {
+			e1 := New("e1")
+			e2 := New("e2")
+			So(NewMultiErr([]error{e1, e2}).Error(), ShouldContainSubstring, "e1")
+			So(NewMultiErr([]error{e1, e2}).Error(), ShouldContainSubstring, "e2")
+			So(NewMultiErr([]error{e1, e2, nil}).Error(), ShouldContainSubstring, "e2")
+		})
+	})
+}

--- a/gobuild.toml
+++ b/gobuild.toml
@@ -1,5 +1,6 @@
 [vars]
   duplLimit = "300"
+  testCoverage = 1
 
 [metalinter]
   [metalinter.enabled]

--- a/maestro/load.go
+++ b/maestro/load.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/safeexec"
 )
 
@@ -92,7 +93,7 @@ func (l *Loader) Load(filename string) (*Config, error) {
 	var conf Config
 
 	if err = json.Unmarshal([]byte(stdout), &conf); err != nil {
-		return nil, err
+		return nil, errors.Annotate(err, "cannot unmarshal to stdout")
 	}
 	return &conf, nil
 }

--- a/maestro/maestro.go
+++ b/maestro/maestro.go
@@ -1,11 +1,12 @@
 package maestro
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/signalfx/golib/errors"
 )
 
 // Maestro is the golang client for https://github.com/signalfuse/maestro-ng
@@ -93,11 +94,11 @@ func (m *Maestro) GetSpecificHost(service string, container string) (string, err
 func (m *Maestro) GetPort(name string) (uint16, error) {
 	sname, err := m.GetServiceName()
 	if err != nil {
-		return 0, err
+		return 0, errors.Annotate(err, "cannot load service for port")
 	}
 	cname, err := m.GetContainerName()
 	if err != nil {
-		return 0, err
+		return 0, errors.Annotate(err, "cannot load container name for port")
 	}
 	return m.GetSpecificExposedPort(sname, cname, name)
 }

--- a/safeexec/safeexec.go
+++ b/safeexec/safeexec.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/logherd"
 )
 
@@ -27,5 +28,5 @@ func Execute(name string, stdin string, args ...string) (string, string, error) 
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
+	return stdout.String(), stderr.String(), errors.Annotatef(err, "cannot run command %s", name)
 }

--- a/schedexec/schedexec.go
+++ b/schedexec/schedexec.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/timekeeper"
 )
 
@@ -53,7 +54,7 @@ func (se *ScheduledExecutor) StartWithMsgChan(iterationFunc func() error, msgCha
 		select {
 		case <-timer.Chan():
 			if err := iterationFunc(); err != nil {
-				return err
+				return errors.Annotate(err, "iteration function failure")
 			}
 			sleepDuration = time.Duration(atomic.LoadInt64(&se.scheduleRate))
 			timer = se.TimeKeeper.NewTimer(sleepDuration)

--- a/schedexec/schedexec_test.go
+++ b/schedexec/schedexec_test.go
@@ -1,12 +1,12 @@
 package schedexec
 
 import (
-	"errors"
 	"testing"
 	"time"
 
 	"sync/atomic"
 
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/timekeeper/timekeepertest"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,7 +62,7 @@ func TestScheduleExecutorTick(t *testing.T) {
 	stubTime.Incr(duration)
 
 	<-doneChan
-	assert.Equal(t, scheduled.runOneIterationError, err)
+	assert.Equal(t, scheduled.runOneIterationError, errors.Tail(err))
 
 }
 

--- a/sfxclient/sfxclient.go
+++ b/sfxclient/sfxclient.go
@@ -1,7 +1,7 @@
 package sfxclient
 
 import (
-	"errors"
+	"expvar"
 	"fmt"
 	"runtime"
 	"sync"
@@ -10,9 +10,9 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/logherd"
-	// TODO: Figure out a way to not have this dependency
-	"expvar"
 
+	// TODO: Figure out a way to not have this dependency
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/metricproxy/dp/dpsink"
 	"github.com/signalfx/metricproxy/protocol/signalfx"
 	"golang.org/x/net/context"
@@ -176,7 +176,7 @@ func (s *Reporter) collectDatapoints(ctx context.Context) ([]*datapoint.Datapoin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, errors.Annotate(ctx.Err(), "context closed")
 	}
 
 	now := time.Now()

--- a/sfxclient/sfxclient_test.go
+++ b/sfxclient/sfxclient_test.go
@@ -1,12 +1,12 @@
 package sfxclient
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/metricproxy/protocol/signalfx"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -59,7 +59,7 @@ func TestBadContext(t *testing.T) {
 	x.Endpoint(testSrvr.URL)
 	cancelFunc()
 	<-ctx.Done()
-	assert.Equal(t, context.Canceled, x.Report(ctx))
+	assert.Equal(t, context.Canceled, errors.Tail(x.Report(ctx)))
 }
 
 func TestNoMetrics(t *testing.T) {

--- a/sfxclient/timeseries.go
+++ b/sfxclient/timeseries.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/errors"
 )
 
 // A Timeseries is an object that holds some value over time, reportable to signalfx
@@ -61,7 +62,7 @@ func (s *Timeseries) convertToDatapoint(extraDimensions map[string]string, curTi
 	defer s.mu.Unlock()
 	val, err := s.value.GetValue()
 	if err != nil {
-		return nil, err
+		return nil, errors.Annotate(err, "cannot fetch value")
 	}
 	dims := make(map[string]string, len(extraDimensions)+len(s.dimensions))
 	for k, v := range extraDimensions {

--- a/sfxtest/sfxtest_test.go
+++ b/sfxtest/sfxtest_test.go
@@ -2,8 +2,9 @@ package sfxtest
 
 import (
 	"errors"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestForcedErr(t *testing.T) {

--- a/zkplus/builder.go
+++ b/zkplus/builder.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/zkplus/zktest"
 )
 
@@ -62,7 +63,7 @@ func (b *Builder) AppendPathPrefix(childPath string) *Builder {
 func (b *Builder) BuildDirect() (*ZkPlus, <-chan zk.Event, error) {
 	z, err := b.Build()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Annotate(err, "cannot build zk connection")
 	}
 	return z, z.EventChan(), nil
 }

--- a/zkplus/builder_test.go
+++ b/zkplus/builder_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"net"
+
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/zkplus/zktest"
 	"github.com/stretchr/testify/assert"
-	"net"
 )
 
 func TestInnerBuilder(t *testing.T) {
@@ -39,7 +41,7 @@ func TestBuildBadPath(t *testing.T) {
 	assert.Equal(t, errInvalidPathSuffix, err)
 
 	_, _, err = builder.BuildDirect()
-	assert.Equal(t, errInvalidPathSuffix, err)
+	assert.Equal(t, errInvalidPathSuffix, errors.Tail(err))
 
 	zkp, err := builder.PathPrefix("").Build()
 	assert.NoError(t, err)

--- a/zkplus/zkplus.go
+++ b/zkplus/zkplus.go
@@ -1,7 +1,6 @@
 package zkplus
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/samuel/go-zookeeper/zk"
+	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/zkplus/zktest"
 )
 
@@ -97,7 +97,7 @@ func (z *ZkPlus) ensureRootPath(conn zktest.ZkConnSupported) error {
 		totalPath = totalPath + "/" + p
 		_, err := conn.Create(totalPath, []byte(""), 0, zk.WorldACL(zk.PermAll))
 		if err != nil && err != zk.ErrNodeExists {
-			return err
+			return errors.Annotatef(err, "cannot create path %s", totalPath)
 		}
 	}
 	return nil
@@ -236,7 +236,7 @@ func (z *ZkPlus) Create(path string, data []byte, flags int32, acl []zk.ACL) (st
 	if strings.HasPrefix(p, z.pathPrefix) && z.pathPrefix != "" {
 		p = p[len(z.pathPrefix)+1:]
 	}
-	return p, err
+	return p, errors.Annotatef(err, "cannot create zk path %s", path)
 }
 
 // Set the data of a zk node


### PR DESCRIPTION
New error library that represents errors as a linked list.  When ```return err``` is used too much, it creates ambiguous errors higher up the stack.  This turns errors that were

```zk: node already exists```

Into this:

```[unhandled ZK error on Create of service1 | cannot create zk path /service1 | zk: node already exists]```