### PR TITLE
Allow disabling default logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script:
   - export PATH=$HOME/gopath/bin:$PATH
   - export GOCOVERDIR_DIR="."
-  - gobuild
+  - env GOLIB_LOG=/dev/null gobuild
 
 after_script:
   - cat coverage.out

--- a/circle.sh
+++ b/circle.sh
@@ -38,7 +38,7 @@ function do_cache() {
 export IDX=0
 function gobuildit() {
   IDX=$((IDX+1))
-  gobuild -verbose -filename_prefix "$IDX" -verbosefile "$CIRCLE_ARTIFACTS/${IDX}gobuildout.txt" check "$1"
+  env GOLIB_LOG=/dev/null gobuild -verbose -filename_prefix "$IDX" -verbosefile "$CIRCLE_ARTIFACTS/${IDX}gobuildout.txt" check "$1"
   RET="$?"
   return $RET
 }

--- a/disco/disco_test.go
+++ b/disco/disco_test.go
@@ -280,6 +280,7 @@ func testAdvertise(t *testing.T, zkConnFunc ZkConnCreatorFunc, zkConnFunc2 ZkCon
 	service, err := d1.Services("TestAdvertiseService")
 	require.NoError(t, err)
 	require.Equal(t, 0, len(service.ServiceInstances()))
+	require.Equal(t, "name=TestAdvertiseService|len(watch)=0|instances=[]", service.String())
 	seen := make(chan struct{}, 5)
 	service.Watch(ChangeWatch(func() {
 		fmt.Printf("Event seen!\n")

--- a/log/hierarchy_test.go
+++ b/log/hierarchy_test.go
@@ -18,6 +18,15 @@ func TestHierarchy(t *testing.T) {
 	Convey("hierarchy logger", t, func() {
 		counter := &Counter{}
 		p1 := NewHierarchy(counter)
+		Convey("should be able to setup", func() {
+			p1.setupFromEnv(func(string) string { return "" })
+			p1.Log("hello", "world")
+			So(counter.Count, ShouldEqual, 1)
+			p1.setupFromEnv(func(string) string { return "/dev/null" })
+
+			p1.Log("hello", "world")
+			So(counter.Count, ShouldEqual, 1)
+		})
 		Convey("Should log", func() {
 			p1.Log("hello")
 			So(counter.Count, ShouldEqual, 1)


### PR DESCRIPTION
While on, it is messing up go-junit-report's ability to create junit XML
reports from stdout/stderr.