### PR TITLE
add asynchronous multitoken sink for emitting with different tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 
 go:
   - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
 
 before_install:
   - go get -u github.com/signalfx/gobuild
@@ -14,7 +17,11 @@ install:
   - echo -e "Host heroku.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   - echo -e "Host git.apache.org\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-  - go get -d -v -t ./... 
+  - go get -d -v -t ./...
+  - CUR=$PWD
+  - cd "$GOPATH/src/git.apache.org/thrift.git/"
+  - git checkout 53dd39833a08ce33582e5ff31fa18bb4735d6731
+  - cd "$CUR"
 
 script:
   - export PATH=$HOME/gopath/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Various golang libraries we've found useful.
 
+## Dependencies
+
+Please note that there is a dependency on Thrift v0.9.3 for some of the libraries in this repository.
+
 ## License
 
 Apache Software License v2. Copyright © 2015-2017 SignalFx

--- a/clientcfg/client.go
+++ b/clientcfg/client.go
@@ -1,0 +1,119 @@
+package clientcfg
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/distconf"
+	"github.com/signalfx/golib/errors"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/logkey"
+	"github.com/signalfx/golib/sfxclient"
+	"github.com/signalfx/golib/timekeeper"
+	"golang.org/x/net/context"
+)
+
+// ClientConfig configures a SfxClient
+type ClientConfig struct {
+	SourceName        *distconf.Str
+	AuthToken         *distconf.Str
+	Endpoint          *distconf.Str
+	ReportingInterval *distconf.Duration
+	TimeKeeper        timekeeper.TimeKeeper
+	OsHostname        func() (name string, err error)
+}
+
+// Load the client config values from distconf
+func (c *ClientConfig) Load(d *distconf.Distconf) {
+	c.SourceName = d.Str("sourceName", "")
+	c.AuthToken = d.Str("auth_token", "")
+	c.Endpoint = d.Str("statsendpoint", "")
+	c.ReportingInterval = d.Duration("report_interval", time.Second)
+	c.TimeKeeper = timekeeper.RealTime{}
+	c.OsHostname = os.Hostname
+}
+
+// DefaultDimensions extracts default sfxclient dimensions that identify the host
+func DefaultDimensions(conf *ClientConfig) (map[string]string, error) {
+	signalfuseSourceName := conf.SourceName.Get()
+	if signalfuseSourceName != "" {
+		return map[string]string{"sf_source": signalfuseSourceName}, nil
+	}
+	hostname, err := conf.OsHostname()
+	if err != nil {
+		return nil, errors.Annotate(err, "unable to get hostname for default source")
+	}
+	return map[string]string{"sf_source": hostname}, nil
+}
+
+// ClientConfigChangerSink is a sink that can update auth and endpoint values
+type ClientConfigChangerSink struct {
+	Destination *sfxclient.HTTPSink
+	mu          sync.RWMutex
+	logger      log.Logger
+	urlParse    func(string) (url *url.URL, err error)
+}
+
+// WatchSinkChanges returns a new ClientConfigChangerSink that wraps a sink with auth/endpoint changes from distconf
+func WatchSinkChanges(sink sfxclient.Sink, Conf *ClientConfig, logger log.Logger) sfxclient.Sink {
+	httpSink, ok := sink.(*sfxclient.HTTPSink)
+	if !ok {
+		return sink
+	}
+	ret := &ClientConfigChangerSink{
+		Destination: httpSink,
+		urlParse:    url.Parse,
+		logger:      logger,
+	}
+	ret.authTokenWatch(Conf.AuthToken, "")
+	ret.endpointWatch(Conf.Endpoint, "")
+	ret.endpointWatch(Conf.Endpoint, "")
+	Conf.Endpoint.Watch(ret.endpointWatch)
+	Conf.AuthToken.Watch(ret.authTokenWatch)
+	return ret
+}
+
+// AddDatapoints forwards the call to Destination
+func (s *ClientConfigChangerSink) AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) (err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Destination.AddDatapoints(ctx, points)
+}
+
+func (s *ClientConfigChangerSink) authTokenWatch(str *distconf.Str, oldValue string) {
+	s.logger.Log("auth watch")
+	s.mu.Lock()
+	s.Destination.AuthToken = str.Get()
+	s.mu.Unlock()
+}
+
+// endpointWatch returns a distconf watch that sets the correct ingest endpoint for a signalfx
+// client
+func (s *ClientConfigChangerSink) endpointWatch(str *distconf.Str, oldValue string) {
+	s.logger.Log("endpoint watch")
+	e := str.Get()
+	if e == "" {
+		return
+	}
+	if !strings.HasPrefix(e, "http") {
+		e = "http://" + e
+	}
+	u, err := s.urlParse(e)
+	if err != nil {
+		s.logger.Log(logkey.Endpoint, e, log.Err, err, "unable to parse URL")
+		return
+	}
+	if u.Path == "" {
+		u.Path = "/v2/datapoint"
+	}
+	if e != "" {
+		s.logger.Log(logkey.Endpoint, e, logkey.URL, u, "updating reporter endpoint")
+		s.mu.Lock()
+		s.Destination.DatapointEndpoint = u.String()
+		s.mu.Unlock()
+	}
+}

--- a/clientcfg/client_test.go
+++ b/clientcfg/client_test.go
@@ -1,0 +1,82 @@
+package clientcfg
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/signalfx/golib/datapoint/dptest"
+	"github.com/signalfx/golib/distconf"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/sfxclient"
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/net/context"
+)
+
+func TestClient(t *testing.T) {
+	Convey("With a testing zk", t, func() {
+		mem := distconf.Mem()
+		dconf := distconf.New([]distconf.Reader{mem})
+		conf := &ClientConfig{}
+		logger := log.Discard
+		conf.Load(dconf)
+		ctx := context.Background()
+		Convey("normal sinks should just forward", func() {
+			tsink := dptest.NewBasicSink()
+			tsink.Resize(1)
+			sink := WatchSinkChanges(tsink, conf, logger)
+			So(sink, ShouldEqual, tsink)
+			So(sink.AddDatapoints(ctx, nil), ShouldBeNil)
+		})
+		Convey("default dimensions", func() {
+			Convey("should use sourceName", func() {
+				mem.Write("sourceName", []byte("h1"))
+				dims, err := DefaultDimensions(conf)
+				So(err, ShouldBeNil)
+				So(dims, ShouldResemble, map[string]string{"sf_source": "h1"})
+			})
+			Convey("should use hostname", func() {
+				conf.OsHostname = func() (name string, err error) {
+					return "ahost", nil
+				}
+				dims, err := DefaultDimensions(conf)
+				So(err, ShouldBeNil)
+				So(dims, ShouldResemble, map[string]string{"sf_source": "ahost"})
+			})
+			Convey("check hostname error", func() {
+				conf.OsHostname = func() (name string, err error) {
+					return "", errors.New("nope")
+				}
+				dims, err := DefaultDimensions(conf)
+				So(err, ShouldNotBeNil)
+				So(dims, ShouldBeNil)
+			})
+		})
+		Convey("HTTPSink should wrap", func() {
+			hsink := sfxclient.NewHTTPSink()
+			sink := WatchSinkChanges(hsink, conf, logger)
+			So(sink, ShouldNotEqual, hsink)
+			hsink.DatapointEndpoint = ""
+			So(sink.AddDatapoints(ctx, nil), ShouldBeNil)
+			Convey("Only hostname should append v2/datapoint", func() {
+				mem.Write("statsendpoint", []byte("https://ingest-2.signalfx.com"))
+				So(hsink.DatapointEndpoint, ShouldEqual, "https://ingest-2.signalfx.com/v2/datapoint")
+				Convey("Failing URL parses should be OK", func() {
+					sink.(*ClientConfigChangerSink).urlParse = func(string) (*url.URL, error) {
+						return nil, errors.New("nope")
+					}
+					mem.Write("statsendpoint", []byte("_will_not_parse"))
+					So(hsink.DatapointEndpoint, ShouldEqual, "https://ingest-2.signalfx.com/v2/datapoint")
+				})
+			})
+			Convey("http should add by default", func() {
+				mem.Write("statsendpoint", []byte("ingest-3.signalfx.com:28080"))
+				So(hsink.DatapointEndpoint, ShouldEqual, "http://ingest-3.signalfx.com:28080/v2/datapoint")
+			})
+			Convey("direct URL should be used", func() {
+				mem.Write("statsendpoint", []byte("https://ingest-4.signalfx.com/v2"))
+				So(hsink.DatapointEndpoint, ShouldEqual, "https://ingest-4.signalfx.com/v2")
+			})
+		})
+	})
+}

--- a/gobuild.toml
+++ b/gobuild.toml
@@ -1,6 +1,7 @@
 [vars]
   duplLimit = "300"
   testCoverage = 100.0
+  testFlags = ["-covermode", "atomic", "-race", "-timeout", "60s", "-cpu", "4", "-parallel", "8"]
 
 [metalinter]
   [metalinter.ignored]
@@ -9,11 +10,12 @@
     logargs = "no args in Log call"
     logval = "in Log call is a function value, not a function call"
     coverageignored = "ignored is unused"
+    unrecognizedverb = "^.*unrecognized printf verb 'n'.*$"
   [metalinter.enabled]
     golint = true
     gofmt = true
     varcheck = true
-    aligncheck = true
+    maligned = true
     gocyclo = true
     vet = true
     deadcode = true

--- a/logkey/keys.go
+++ b/logkey/keys.go
@@ -43,4 +43,26 @@ var (
 	ExplorableParts = log.Key("parts")
 	// URL is a URL endpoint
 	URL = log.Key("url")
+
+	// Endpoint is the URL endpoint that metrics go to
+	Endpoint = log.Key("endpoint")
+	// Name is the name of some item or group of things
+	Name = log.Key("name")
+
+	// PublishAddr is the address a server listens on
+	PublishAddr = log.Key("publishAddr")
+	// Size is the length of some set
+	Size = log.Key("size")
+	// Index is an integer index into an array
+	Index = log.Key("index")
+	// RetryAttempt is an index retrying an action
+	RetryAttempt = log.Key("retry_attempt")
+	// Env is the os environment
+	Env = log.Key("env")
+	// ConnCount is a count of connections
+	ConnCount = log.Key("connection_count")
+	// Time that a log event happens at
+	Time = log.Key("time")
+	// Caller is the file/line of the log statement
+	Caller = log.Key("caller")
 )

--- a/reportSHA/reportsha.go
+++ b/reportSHA/reportsha.go
@@ -1,0 +1,71 @@
+package reportsha
+
+import (
+	"encoding/json"
+	"expvar"
+	"fmt"
+	"io/ioutil"
+	"sync"
+
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/logkey"
+	"github.com/signalfx/golib/sfxclient"
+)
+
+// SHA1Reporter reports a gauge to Client that is the commit SHA1 of the current image
+type SHA1Reporter struct {
+	RepoURL  string
+	FileName string
+	Logger   log.Logger
+	Fi       fileInfo
+	oc       sync.Once
+}
+
+type fileInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Builder string `json:"builder"`
+	Commit  string `json:"commit"`
+	Source  string
+}
+
+func load(fileName string) (fileInfo, error) {
+	var fi fileInfo
+	contents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return fi, err
+	}
+	if err := json.Unmarshal(contents, &fi); err != nil {
+		return fi, err
+	}
+	return fi, nil
+}
+
+func (s *SHA1Reporter) loadFileInfo() {
+	s.oc.Do(func() {
+		fi, err := load(s.FileName)
+		if err != nil {
+			s.Logger.Log(log.Err, err, logkey.Name, s.FileName, "Cannot load file info!")
+			return
+		}
+		fi.Source = fmt.Sprintf("%s/tree/%s", s.RepoURL, fi.Commit)
+		s.Fi = fi
+	})
+}
+
+// Var returns an expvar that is the build file info
+func (s *SHA1Reporter) Var() expvar.Var {
+	s.loadFileInfo()
+	return expvar.Func(func() interface{} {
+		return s.Fi
+	})
+}
+
+// Datapoints returns a single datapoint that includes the commit sha loaded from a config file
+func (s *SHA1Reporter) Datapoints() []*datapoint.Datapoint {
+	s.loadFileInfo()
+	return []*datapoint.Datapoint{
+		sfxclient.Gauge("fileinfo_commit", map[string]string{"commit": s.Fi.Commit}, int64(1)),
+	}
+}

--- a/reportSHA/reportsha_test.go
+++ b/reportSHA/reportsha_test.go
@@ -1,0 +1,51 @@
+package reportsha
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/signalfx/golib/log"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestReportSha(t *testing.T) {
+	Convey("when setup", t, func() {
+		buildInfo := `{
+  "name": "service",
+  "version": "1.0-SNAPSHOT",
+  "builder": "CI",
+  "commit": "b70a843b07741e04ce6845aaefdbcb077787b4a3"
+}`
+		tmpFile, err := ioutil.TempFile("", "reportsha")
+		So(err, ShouldBeNil)
+		_, err = tmpFile.WriteString(buildInfo)
+		So(err, ShouldBeNil)
+
+		reporter := SHA1Reporter{
+			FileName: tmpFile.Name(),
+			Logger:   log.Discard,
+		}
+
+		Convey("Commit should load ok", func() {
+			dps := reporter.Datapoints()
+			So(dps[0].Dimensions["commit"], ShouldEqual, "b70a843b07741e04ce6845aaefdbcb077787b4a3")
+			So(reporter.Var().String(), ShouldContainSubstring, "b70a843b07741e04ce6845aaefdbcb077787b4a3")
+		})
+
+		Convey("Invalid files should not load", func() {
+			_, _ = tmpFile.WriteString("asdfsadfsad")
+			So(reporter.Var().String(), ShouldNotContainSubstring, "asdf")
+		})
+
+		Convey("Invalid file names should not load", func() {
+			reporter.FileName = "asdfsadfsad"
+			So(reporter.Var().String(), ShouldNotContainSubstring, "asdf")
+		})
+
+		Reset(func() {
+			So(os.Remove(tmpFile.Name()), ShouldBeNil)
+			So(tmpFile.Close(), ShouldBeNil)
+		})
+	})
+}

--- a/sfxclient/multitokensink.go
+++ b/sfxclient/multitokensink.go
@@ -1,0 +1,654 @@
+package sfxclient
+
+import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
+	"golang.org/x/net/context"
+)
+
+// ContextKey is a custom key type for context values
+type ContextKey string
+
+const (
+	// TokenCtxKey is a context key for tokens
+	TokenCtxKey ContextKey = TokenHeaderName
+)
+
+// dpMsg is the message object for datapoints
+type dpMsg struct {
+	token string
+	data  []*datapoint.Datapoint
+}
+
+// evMsg is the message object for events
+type evMsg struct {
+	token string
+	data  []*event.Event
+}
+
+type tokenStatus struct {
+	status int
+	token  string
+	val    int64
+}
+
+// AsyncTokenStatusCounter is a counter and collector for http statuses by token
+type AsyncTokenStatusCounter struct {
+	name              string
+	dataStore         map[string]map[int]int64
+	input             chan *tokenStatus
+	stop              chan bool
+	requestDatapoints chan chan []*datapoint.Datapoint
+	defaultDims       map[string]string
+}
+
+func (a *AsyncTokenStatusCounter) fetchDatapoints() (counters []*datapoint.Datapoint) {
+	for token, statuses := range a.dataStore {
+		for status, counter := range statuses {
+			statusString := http.StatusText(status)
+			if statusString == "" {
+				statusString = "unknown"
+			}
+			dims := map[string]string{"token": token, "status": statusString}
+			for k, v := range a.defaultDims {
+				dims[k] = v
+			}
+			counters = append(counters, Cumulative(a.name, dims, counter))
+		}
+	}
+	return
+}
+
+func (a *AsyncTokenStatusCounter) processInput(t *tokenStatus) {
+	if _, ok := a.dataStore[t.token]; !ok {
+		a.dataStore[t.token] = map[int]int64{}
+	}
+	if val, ok := a.dataStore[t.token][t.status]; ok {
+		a.dataStore[t.token][t.status] = val + t.val
+	} else { // if the status doesn't exist add create it
+		a.dataStore[t.token][t.status] = t.val
+	}
+}
+
+// Datapoints returns datapoints for each token and status
+func (a *AsyncTokenStatusCounter) Datapoints() (dps []*datapoint.Datapoint) {
+	var request bool
+	returnDatapoints := make(chan []*datapoint.Datapoint)
+	defer close(returnDatapoints)
+	for {
+		select {
+		case <-a.stop:
+			return
+		case dps = <-returnDatapoints: // listen on the newly created channel for datapoints
+			return
+		default:
+			if !request {
+				a.requestDatapoints <- returnDatapoints
+				request = true
+			}
+		}
+	}
+}
+
+// Increment adds a tokenStatus object to the counter
+func (a *AsyncTokenStatusCounter) Increment(status *tokenStatus) {
+	select {
+	case <-a.stop: // check if the counter has been stopped
+		return
+	default:
+		select {
+		case a.input <- status:
+		default:
+		}
+	}
+}
+
+// NewAsyncTokenStatusCounter returns a structure for counting occurences of http statuses by token
+func NewAsyncTokenStatusCounter(name string, buffer int, numWorkers int64, defaultDims map[string]string) *AsyncTokenStatusCounter {
+	a := &AsyncTokenStatusCounter{
+		name:              name,
+		dataStore:         map[string]map[int]int64{},
+		input:             make(chan *tokenStatus, int64(buffer)*numWorkers),
+		stop:              make(chan bool),
+		requestDatapoints: make(chan chan []*datapoint.Datapoint, 5000),
+		defaultDims:       defaultDims,
+	}
+	go func() {
+		for {
+			select {
+			case <-a.stop: // signal for the goroutine to stop managing the datapoints object
+				return
+			case input := <-a.input:
+				a.processInput(input)
+			case returnDatapoints := <-a.requestDatapoints:
+				response := a.fetchDatapoints()
+				returnDatapoints <- response
+			}
+		}
+	}()
+	return a
+}
+
+// worker manages a pipeline for emitting metrics
+type worker struct {
+	lock         *sync.Mutex       // lock to control concurrent access to the worker
+	errorHandler func(error) error // error handler for handling error emitting datapoints
+	sink         *HTTPSink         // sink is an HTTPSink for emitting datapoints to Signal Fx
+	closing      chan bool         // channel to signal that the worker is stopping
+	done         chan bool         // channel to signal that the worker is done
+}
+
+// returns a new instance of worker with an configured emission pipeline
+func newWorker(errorHandler func(error) error, closing chan bool, done chan bool) *worker {
+	w := &worker{
+		lock:         &sync.Mutex{},
+		sink:         NewHTTPSink(),
+		errorHandler: errorHandler,
+		closing:      closing,
+		done:         done,
+	}
+
+	return w
+}
+
+// worker for handling datapoints
+type datapointWorker struct {
+	*worker
+	input     chan *dpMsg // channel for inputing datapoints into a worker
+	buffer    []*datapoint.Datapoint
+	batchSize int
+	stats     *asyncMultiTokenSinkStats // stats about
+}
+
+// emits a series of datapoints
+func (w *datapointWorker) emit(token string) {
+	// set the token on the HTTPSink
+	w.sink.AuthToken = token
+	// emit datapoints and handle any errors
+	err := w.sink.AddDatapoints(context.Background(), w.buffer)
+	w.handleError(err, token, w.buffer)
+	// account for the emitted datapoints
+	atomic.AddInt64(&w.stats.TotalDatapointsBuffered, int64(len(w.buffer)*-1))
+	w.buffer = w.buffer[:0]
+}
+
+func (w *datapointWorker) handleError(err error, token string, datapoints []*datapoint.Datapoint) {
+	status := &tokenStatus{
+		status: -1,
+		token:  token,
+		val:    int64(len(datapoints)),
+	}
+	if err == nil {
+		status.status = http.StatusOK
+	} else {
+		if obj, ok := err.(SFXAPIError); ok {
+			status.status = obj.StatusCode
+		}
+	}
+	w.stats.TotalDatapointsByToken.Increment(status)
+	if err != nil {
+		_ = w.errorHandler(err)
+	}
+}
+
+func (w *datapointWorker) processMsg(msg *dpMsg) {
+	for len(msg.data) > 0 {
+		msgLength := len(msg.data)
+		remainingBuffer := (w.batchSize - len(w.buffer))
+		if msgLength > remainingBuffer {
+			msgLength = remainingBuffer
+		}
+		w.buffer = append(w.buffer, msg.data[:msgLength]...)
+		msg.data = msg.data[msgLength:]
+		if len(w.buffer) >= w.batchSize {
+			w.emit(msg.token)
+		}
+	}
+}
+
+// bufferDatapoints is responsible for batching incoming datapoints into a buffer
+func (w *datapointWorker) bufferFunc(msg *dpMsg) (stop bool) {
+	var lastTokenSeen = msg.token
+	w.processMsg(msg)
+outer:
+	for len(w.buffer) < w.batchSize {
+		select {
+		case msg = <-w.input:
+			if msg.token != lastTokenSeen {
+				// if the token changes, then emit what ever is in the buffer before proceeding
+				w.emit(lastTokenSeen)
+				lastTokenSeen = msg.token
+			}
+			w.processMsg(msg)
+		default:
+			break outer // emit what ever is in the buffer if there are no more datapoints to read
+		}
+	}
+	// emit the data in the buffer
+	w.emit(msg.token)
+	return
+}
+
+// newBuffer buffers datapoints and events in the pipeline for the duration specified during Startup
+func (w *datapointWorker) newBuffer() {
+	go func() {
+		for {
+			select {
+			// check if the sink is closing and return if so
+			// reading from a.closing will only return a value if the a.closing channel is closed
+			// nothing should ever write into it
+			case <-w.closing: // check if the worker is in a closing state
+				w.done <- true
+				return
+			case msg := <-w.input:
+				// process the Datapoint Message
+				w.bufferFunc(msg)
+			}
+		}
+	}()
+}
+
+func newDatapointWorker(maxBuffer int, batchSize int, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool) *datapointWorker {
+	w := &datapointWorker{
+		worker:    newWorker(errorHandler, closing, done),
+		input:     make(chan *dpMsg, maxBuffer),
+		buffer:    make([]*datapoint.Datapoint, 0, batchSize),
+		batchSize: batchSize,
+		stats:     stats,
+	}
+	w.newBuffer()
+	return w
+}
+
+// worker for handling events
+type eventWorker struct {
+	*worker
+	input     chan *evMsg // channel for inputing datapoints into a worker
+	buffer    []*event.Event
+	batchSize int
+	stats     *asyncMultiTokenSinkStats // stats about
+}
+
+// emits a series of datapoints
+func (w *eventWorker) emit(token string) {
+	// set the token on the HTTPSink
+	w.sink.AuthToken = token
+
+	// emit datapoints and handle any errors
+	err := w.sink.AddEvents(context.Background(), w.buffer)
+	w.handleError(err, token, w.buffer)
+	// account for the emitted datapoints
+	atomic.AddInt64(&w.stats.TotalEventsBuffered, int64(len(w.buffer)*-1))
+	w.buffer = w.buffer[:0]
+}
+
+func (w *eventWorker) handleError(err error, token string, events []*event.Event) {
+	status := &tokenStatus{
+		status: -1,
+		token:  token,
+		val:    int64(len(events)),
+	}
+	if err == nil {
+		status.status = http.StatusOK
+	} else {
+		// parse the http status code from the error returned by the httpsink
+		if obj, ok := err.(SFXAPIError); ok {
+			status.status = obj.StatusCode
+		}
+	}
+	w.stats.TotalEventsByToken.Increment(status)
+	if err != nil {
+		_ = w.errorHandler(err)
+	}
+}
+
+func (w *eventWorker) processMsg(msg *evMsg) {
+	for len(msg.data) > 0 {
+		msgLength := len(msg.data)
+		remainingBuffer := (w.batchSize - len(w.buffer))
+		if msgLength > remainingBuffer {
+			msgLength = remainingBuffer
+		}
+		w.buffer = append(w.buffer, msg.data[:msgLength]...)
+		msg.data = msg.data[msgLength:]
+		if len(w.buffer) >= w.batchSize {
+			w.emit(msg.token)
+		}
+	}
+}
+
+// bufferDatapoints is responsible for batching incoming datapoints into a buffer
+func (w *eventWorker) bufferFunc(msg *evMsg) (stop bool) {
+	var lastTokenSeen = msg.token
+	w.processMsg(msg)
+outer:
+	for len(w.buffer) < w.batchSize {
+		select {
+		case msg = <-w.input:
+			if msg.token != lastTokenSeen {
+				// if the token changes, then emit what ever is in the buffer before proceeding
+				w.emit(lastTokenSeen)
+				lastTokenSeen = msg.token
+			}
+			w.processMsg(msg)
+		default:
+			break outer // emit what ever is in the buffer if there are no more datapoints to read
+		}
+	}
+	// emit the data in the buffer
+	w.emit(msg.token)
+	return
+}
+
+// newBuffer buffers datapoints and events in the pipeline for the duration specified during Startup
+func (w *eventWorker) newBuffer() {
+	go func() {
+		for {
+			select {
+			// check if the sink is closing and return if so
+			// reading from a.closing will only return a value if the a.closing channel is closed
+			// nothing should ever write into it
+			case <-w.closing:
+				// signal that the worker is done
+				w.done <- true
+				return
+			case msg := <-w.input:
+				// process the Datapoint Message
+				w.bufferFunc(msg)
+			}
+		}
+	}()
+}
+
+func newEventWorker(maxBuffer int, batchSize int, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool) *eventWorker {
+	w := &eventWorker{
+		worker:    newWorker(errorHandler, closing, done),
+		input:     make(chan *evMsg, maxBuffer),
+		buffer:    make([]*event.Event, 0, batchSize),
+		batchSize: batchSize,
+		stats:     stats,
+	}
+	w.newBuffer()
+	return w
+}
+
+//asyncMultiTokenSinkStats - holds stats about the sink
+type asyncMultiTokenSinkStats struct {
+	DefaultDimensions        map[string]string
+	TotalDatapointsByToken   *AsyncTokenStatusCounter
+	TotalEventsByToken       *AsyncTokenStatusCounter
+	TotalDatapointsBuffered  int64
+	TotalEventsBuffered      int64
+	NumberOfDatapointWorkers int64
+	NumberOfEventWorkers     int64
+}
+
+func (a *asyncMultiTokenSinkStats) Close() {
+	close(a.TotalDatapointsByToken.stop)
+	close(a.TotalEventsByToken.stop)
+}
+
+func newAsyncMultiTokenSinkStats(buffer int, workerCount int64, batchSize int) *asyncMultiTokenSinkStats {
+	defaultDims := map[string]string{
+		"buffer_size":  strconv.Itoa(buffer),
+		"worker_count": strconv.FormatInt(workerCount, 10),
+		"batch_size":   strconv.Itoa(batchSize),
+	}
+	return &asyncMultiTokenSinkStats{
+		DefaultDimensions:        defaultDims,
+		TotalDatapointsByToken:   NewAsyncTokenStatusCounter("total_datapoints_by_token", buffer, workerCount, defaultDims),
+		TotalEventsByToken:       NewAsyncTokenStatusCounter("total_events_by_token", buffer, workerCount, defaultDims),
+		TotalDatapointsBuffered:  0,
+		TotalEventsBuffered:      0,
+		NumberOfDatapointWorkers: 0,
+		NumberOfEventWorkers:     0,
+	}
+}
+
+// AsyncMultiTokenSink asynchronously sends datapoints for multiple tokens
+type AsyncMultiTokenSink struct {
+	ShutdownTimeout time.Duration     // ShutdownTimeout is how long the sink should wait before timing out after Close() is called
+	errorHandler    func(error) error // error handler is a handler for errors encountered while emitting metrics
+	Hasher          hash.Hash32       // Hasher is used to hash access tokens to a worker
+	lock            sync.RWMutex      // lock is a mutex preventing concurrent access to getWorker
+	// closing is channel to signal the workers that the sink is closing
+	// nothing is ever passed to the channel it is just open and
+	// it will be read from by multiple select statements across multiple workers
+	// when the channel is closed by close() all of the select statements reading from the channel will receive nil.
+	// this is a broadcast mechanism to signal at once to everything that the sink is closing.
+	closing       chan bool
+	dpDone        chan bool
+	evDone        chan bool
+	dpWorkers     []*datapointWorker        // dpWorkers is an array of workers used to emit datapoints asynchronously
+	evWorkers     []*eventWorker            // evWorkers is an array of workers dedicated to sending events
+	dpBuffered    int64                     // number of datapoints in the sink that haven't been emitted
+	evBuffered    int64                     // number of events in the sink that haven't been emitted
+	NewHTTPClient func() http.Client        // function used to create an http client for the underlying sinks
+	stats         *asyncMultiTokenSinkStats //stats are stats about that sink that can be collected from the Datapoitns() method
+}
+
+// Datapoints returns a set of datapoints about the sink
+func (a *AsyncMultiTokenSink) Datapoints() (dps []*datapoint.Datapoint) {
+	dps = append(dps, Cumulative("total_datapoints_buffered", a.stats.DefaultDimensions, atomic.LoadInt64(&a.stats.TotalDatapointsBuffered)))
+	dps = append(dps, Cumulative("total_events_buffered", a.stats.DefaultDimensions, atomic.LoadInt64(&a.stats.TotalEventsBuffered)))
+	dps = append(dps, a.stats.TotalDatapointsByToken.Datapoints()...)
+	dps = append(dps, a.stats.TotalEventsByToken.Datapoints()...)
+	return
+}
+
+// getWorker hashes the string to one of the workers and returns the integer position of the worker
+func (a *AsyncMultiTokenSink) getWorker(input string, size int) (workerID int64, err error) {
+	a.lock.Lock()
+	if a.Hasher != nil {
+		a.Hasher.Reset()
+		_, _ = a.Hasher.Write([]byte(input))
+		if size > 0 {
+			workerID = int64(a.Hasher.Sum32()) % int64(size)
+		} else {
+			err = fmt.Errorf("no available workers")
+		}
+	} else {
+		err = fmt.Errorf("hasher is nil")
+	}
+	a.lock.Unlock()
+	return
+}
+
+// AddDatapointsWithToken emits a list of datapoints using a supplied token
+func (a *AsyncMultiTokenSink) AddDatapointsWithToken(token string, datapoints []*datapoint.Datapoint) (err error) {
+	var workerID int64
+	if workerID, err = a.getWorker(token, len(a.dpWorkers)); err == nil {
+		var worker = a.dpWorkers[workerID]
+		_ = atomic.AddInt64(&a.dpBuffered, int64(len(datapoints)))
+		var m = &dpMsg{
+			token: token,
+			data:  datapoints,
+		}
+		select {
+		// check if the sink is closing and return if so
+		// reading from a.closing will only return a value if the a.closing channel is closed
+		case <-a.closing:
+			err = fmt.Errorf("unable to add datapoints: the worker has been stopped")
+		default:
+			select {
+			case worker.input <- m:
+				atomic.AddInt64(&a.stats.TotalDatapointsBuffered, int64(len(datapoints)))
+			default:
+				err = fmt.Errorf("unable to add datapoints: the input buffer is full")
+			}
+		}
+	} else {
+		err = fmt.Errorf("unable to add datapoints: there was an error while hashing the token to a worker. %v", err)
+	}
+
+	return
+}
+
+// AddDatapoints add datepoints to the multitoken sync using a context that has the TokenCtxKey
+func (a *AsyncMultiTokenSink) AddDatapoints(ctx context.Context, datapoints []*datapoint.Datapoint) (err error) {
+	if token := ctx.Value(TokenCtxKey); token != nil {
+		err = a.AddDatapointsWithToken(token.(string), datapoints)
+	} else {
+		err = fmt.Errorf("no value was found on the context with key '%s'", TokenCtxKey)
+	}
+	return
+}
+
+// AddEventsWithToken emits a list of events using a supplied token
+func (a *AsyncMultiTokenSink) AddEventsWithToken(token string, events []*event.Event) (err error) {
+	var workerID int64
+	if workerID, err = a.getWorker(token, len(a.evWorkers)); err == nil {
+		var worker = a.evWorkers[workerID]
+		_ = atomic.AddInt64(&a.evBuffered, int64(len(events)))
+		var m = &evMsg{
+			token: token,
+			data:  events,
+		}
+		select {
+		// check if the sink is closing and return if so
+		// reading from a.closing will only return a value if the a.closing channel is closed
+		case <-a.closing:
+			err = fmt.Errorf("unable to add events: the worker has been stopped")
+		default:
+			select {
+			case worker.input <- m:
+				atomic.AddInt64(&a.stats.TotalEventsBuffered, int64(len(events)))
+			default:
+				err = fmt.Errorf("unable to add events: the input buffer is full")
+			}
+		}
+
+	} else {
+		err = fmt.Errorf("unable to add events: there was an error while hashing the token to a worker. %v", err)
+	}
+
+	return
+}
+
+// AddEvents add datepoints to the multitoken sync using a context that has the TokenCtxKey
+func (a *AsyncMultiTokenSink) AddEvents(ctx context.Context, events []*event.Event) (err error) {
+	if token := ctx.Value(TokenCtxKey); token != nil {
+		err = a.AddEventsWithToken(token.(string), events)
+	} else {
+		err = fmt.Errorf("no value was found on the context with key '%s'", TokenCtxKey)
+	}
+	return
+}
+
+// close workers and get the number of datapoints and events dropped if they do not close cleanly
+func (a *AsyncMultiTokenSink) closeWorkers() (datapointsDropped int64, eventsDropped int64) {
+	// signal to all workers that the sink is closing
+	close(a.closing)
+
+	// timer to timeout close operations
+	timeout := time.After(a.ShutdownTimeout)
+
+done:
+	for {
+		select {
+		case <-timeout:
+			datapointsDropped = atomic.LoadInt64(&a.stats.TotalDatapointsBuffered)
+			eventsDropped = atomic.LoadInt64(&a.stats.TotalEventsBuffered)
+			break done
+		case <-a.dpDone:
+			// return nil if they all are done
+			// order matters here because we need to increment the number of workers before checking if number is 0
+			if atomic.AddInt64(&a.stats.NumberOfDatapointWorkers, -1) == 0 && atomic.LoadInt64(&a.stats.NumberOfEventWorkers) == 0 {
+				break done
+			}
+		case <-a.evDone:
+			// return nil if they all are done
+			// order matters here because we need to increment the number of workers before checking if number is 0
+			if atomic.AddInt64(&a.stats.NumberOfEventWorkers, -1) == 0 && atomic.LoadInt64(&a.stats.NumberOfDatapointWorkers) == 0 {
+				break done
+			}
+		}
+	}
+	a.stats.Close()
+	return
+}
+
+// Close stops the existing workers and prevents additional datapoints from being added
+// if a ShutdownTimeout is set on the sink, it will be used as a timeout for closing the sink
+// the default timeout is 5 seconds
+func (a *AsyncMultiTokenSink) Close() (err error) {
+	// close the workers and collect the number of datapoints and events still buffered
+	datapointsDropped, eventsDropped := a.closeWorkers()
+
+	// if something didn't close cleanly return an appropriate error message
+	if atomic.LoadInt64(&a.stats.NumberOfDatapointWorkers) > 0 || atomic.LoadInt64(&a.stats.NumberOfEventWorkers) > 0 || datapointsDropped > 0 || eventsDropped > 0 {
+		err = fmt.Errorf("some workers (%d) timedout while stopping the sink approximately %d datapoints and %d events may have been dropped",
+			(atomic.LoadInt64(&a.stats.NumberOfDatapointWorkers) + atomic.LoadInt64(&a.stats.NumberOfEventWorkers)), datapointsDropped, eventsDropped)
+	}
+	return
+}
+
+// newDefaultHTTPClient returns a default http client for the sink
+func newDefaultHTTPClient() http.Client {
+	return http.Client{
+		Timeout: DefaultTimeout,
+	}
+}
+
+// NewAsyncMultiTokenSink returns a sink that asynchronously emits datapoints with different tokens
+func NewAsyncMultiTokenSink(numWorkers int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() http.Client, errorHandler func(error) error) *AsyncMultiTokenSink {
+	a := &AsyncMultiTokenSink{
+		ShutdownTimeout: time.Second * 5,
+		errorHandler:    DefaultErrorHandler,
+		dpWorkers:       make([]*datapointWorker, numWorkers),
+		evWorkers:       make([]*eventWorker, numWorkers),
+		Hasher:          fnv.New32(),
+		// closing is channel to signal the workers that the sink is closing
+		// nothing is ever passed to the channel it is just open and
+		// it will be read from by multiple select statements across multiple workers
+		// when the channel is closed by close() all of the select statements reading from the channel will receive nil.
+		// this is a broadcast mechanism to signal at once to everything that the sink is closing.
+		closing: make(chan bool),
+		// make buffered channels to receive done messages from the workers
+		dpDone:        make(chan bool, numWorkers),
+		evDone:        make(chan bool, numWorkers),
+		lock:          sync.RWMutex{},
+		NewHTTPClient: newDefaultHTTPClient,
+		stats:         newAsyncMultiTokenSinkStats(buffer, numWorkers, batchSize),
+	}
+
+	for i := int64(0); i < numWorkers; i++ {
+		dpWorker := newDatapointWorker(buffer, batchSize, a.errorHandler, a.stats, a.closing, a.dpDone)
+		if DatapointEndpoint != "" {
+			dpWorker.sink.DatapointEndpoint = DatapointEndpoint
+		}
+		evWorker := newEventWorker(buffer, batchSize, a.errorHandler, a.stats, a.closing, a.evDone)
+		if EventEndpoint != "" {
+			evWorker.sink.EventEndpoint = EventEndpoint
+		}
+		if userAgent != "" {
+			dpWorker.sink.UserAgent = userAgent
+			evWorker.sink.UserAgent = userAgent
+		}
+		if httpClient != nil {
+			a.NewHTTPClient = httpClient
+		}
+		dpWorker.sink.Client = a.NewHTTPClient()
+		evWorker.sink.Client = a.NewHTTPClient()
+		if errorHandler != nil {
+			a.errorHandler = errorHandler
+		}
+		dpWorker.errorHandler = a.errorHandler
+		evWorker.errorHandler = a.errorHandler
+		a.dpWorkers[i] = dpWorker
+		a.evWorkers[i] = evWorker
+	}
+	_ = atomic.SwapInt64(&a.stats.NumberOfDatapointWorkers, numWorkers)
+	_ = atomic.SwapInt64(&a.stats.NumberOfEventWorkers, numWorkers)
+
+	return a
+}

--- a/sfxclient/multitokensink_test.go
+++ b/sfxclient/multitokensink_test.go
@@ -1,0 +1,483 @@
+package sfxclient
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/net/context"
+)
+
+func TestAsyncMultiTokenSinkStartup(t *testing.T) {
+	Convey("A default sink", t, func() {
+		So(NewAsyncMultiTokenSink(int64(1), 5, 30, IngestEndpointV2, EventIngestEndpointV2, DefaultUserAgent, newDefaultHTTPClient, DefaultErrorHandler), ShouldNotBeNil)
+
+		Convey("should be able to startup successfully", func() {
+			So(NewAsyncMultiTokenSink(int64(1), 5, 30, IngestEndpointV2, EventIngestEndpointV2, DefaultUserAgent, newDefaultHTTPClient, nil), ShouldNotBeNil)
+		})
+
+		Convey("should be able to startup successfully without a timebuffer", func() {
+			So(NewAsyncMultiTokenSink(int64(3), 5, 30, "", "", "", newDefaultHTTPClient, nil), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestAddDataToAsyncMultitokenSink(t *testing.T) {
+	Convey("A default sink", t, func() {
+		s := NewAsyncMultiTokenSink(int64(2), 5, 5000, "", "", "", newDefaultHTTPClient, nil)
+		ctx := context.Background()
+		dps := GoMetricsSource.Datapoints()
+		evs := GoEventSource.Events()
+
+		Convey("shouldn't accept dps and events with a context if a token isn't provided in the context", func() {
+			So(errors.Details(s.AddEvents(ctx, evs)), ShouldContainSubstring, "no value was found on the context with key")
+			So(errors.Details(s.AddDatapoints(ctx, dps)), ShouldContainSubstring, "no value was found on the context with key")
+		})
+
+		Convey("shouldn't accept dps and events if the sink has started, but the workers have shutdown", func() {
+			ctx = context.WithValue(ctx, TokenCtxKey, "HELLOOOOOO")
+			s.ShutdownTimeout = time.Second * 1
+			So(s.Close(), ShouldBeNil)
+			_ = s.AddEvents(ctx, evs)
+			_ = s.AddDatapointsWithToken("HELLOOOOOO", dps)
+			So(errors.Details(s.AddEvents(ctx, evs)), ShouldContainSubstring, "unable to add events: the worker has been stopped")
+			So(errors.Details(s.AddDatapoints(ctx, dps)), ShouldContainSubstring, "unable to add datapoints: the worker has been stopped")
+			So(errors.Details(s.AddEventsWithToken("HELLOOOOO", evs)), ShouldContainSubstring, "unable to add events: the worker has been stopped")
+			So(errors.Details(s.AddDatapointsWithToken("HELLOOOOOO", dps)), ShouldContainSubstring, "unable to add datapoints: the worker has been stopped")
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkClose(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+
+		Convey("should be able to close successfully when no data has been added to it", func() {
+			s := NewAsyncMultiTokenSink(int64(2), 5, 25, "", "", "", newDefaultHTTPClient, nil)
+			So(s, ShouldNotBeNil)
+			s.ShutdownTimeout = time.Millisecond * 500
+			So(s.Close(), ShouldBeNil)
+		})
+	})
+}
+
+func TestWorkerErrorHandler(t *testing.T) {
+	Convey("An AsyncMultiTokeSink Worker", t, func() {
+		Convey("should handle erors while emitting datapoints", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 7, "", "", "", newDefaultHTTPClient, nil)
+			s.ShutdownTimeout = time.Second * 5
+			s.dpWorkers[0].handleError(fmt.Errorf("this is an error"), "HELLOOOOO", []*datapoint.Datapoint{Cumulative("metricname", nil, 64)})
+			time.Sleep(1 * time.Second) // wait for counts to be processed
+			data := s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			t.Log(data)
+			var dpDropped, _, _, _ = ProcessDatapoints(data)
+			So(dpDropped, ShouldEqual, 1)
+		})
+		Convey("should handle nil errors while emitting datapoints", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 7, "", "", "", newDefaultHTTPClient, nil)
+			s.ShutdownTimeout = time.Second * 5
+			s.dpWorkers[0].handleError(nil, "HELLOOOOO", []*datapoint.Datapoint{Cumulative("metricname", nil, 64)})
+			time.Sleep(1 * time.Second) // wait for counts to be processed
+			data := s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			t.Log(data)
+			var dpDropped, _, _, _ = ProcessDatapoints(data)
+			So(dpDropped, ShouldEqual, 0)
+		})
+		Convey("should handle erors while emitting events", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 7, "", "", "", newDefaultHTTPClient, nil)
+			s.ShutdownTimeout = time.Second * 5
+			s.evWorkers[0].handleError(fmt.Errorf("this is an error"), "HELLOOOOO", []*event.Event{event.New("TotalAlloc", event.COLLECTD, nil, time.Time{})})
+			time.Sleep(1 * time.Second) // wait for counts to be processed
+			data := s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			t.Log(data)
+			var _, evDropped, _, _ = ProcessDatapoints(data)
+			So(evDropped, ShouldEqual, 1)
+		})
+		Convey("should handle nil errors while emitting events", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 7, "", "", "", newDefaultHTTPClient, nil)
+			s.ShutdownTimeout = time.Second * 5
+			s.evWorkers[0].handleError(nil, "HELLOOOOO", []*event.Event{event.New("TotalAlloc", event.COLLECTD, nil, time.Time{})})
+			time.Sleep(1 * time.Second) // wait for counts to be processed
+			data := s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			t.Log(data)
+			var _, evDropped, _, _ = ProcessDatapoints(data)
+			So(evDropped, ShouldEqual, 0)
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkShutdownDroppedDatapoints(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should raise an error if it's possible that datapoints were dropped", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 25, "", "", "", newDefaultHTTPClient, nil)
+			dps := GoMetricsSource.Datapoints()
+			s.ShutdownTimeout = (time.Second * 0)
+			// increase the number of datapoints added to the sink in a single call
+			for i := 0; i < 3; i++ {
+				dps = append(dps, GoMetricsSource.Datapoints()...)
+			}
+			// intentionally slow down emission to test shutdown timeout
+			s.errorHandler = func(e error) error {
+				time.Sleep(3 * time.Second)
+				return DefaultErrorHandler(e)
+			}
+			for i := 0; i < 5; i++ {
+				go func() {
+					for i := 0; i < 500000; i++ {
+						_ = s.AddDatapointsWithToken("HELLOOOOOO", dps)
+					}
+				}()
+			}
+			time.Sleep(500 * time.Millisecond) // wait half a second to start filling the buffer
+			So(errors.Details(s.Close()), ShouldContainSubstring, "may have been dropped")
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkShutdownDroppedEvents(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should raise an error if it's possible that events were dropped", func() {
+			s := NewAsyncMultiTokenSink(int64(1), 5, 25, "", "", "", newDefaultHTTPClient, nil)
+			evs := GoEventSource.Events()
+			s.ShutdownTimeout = (time.Second * 0)
+			// increase the number of events added to the sink in a single call
+			for i := 0; i < 3; i++ {
+				evs = append(evs, GoEventSource.Events()...)
+			}
+			// intentionally slow down emission to test shutdown timeout
+			s.errorHandler = func(e error) error {
+				time.Sleep(3 * time.Second)
+				return DefaultErrorHandler(e)
+			}
+			for i := 0; i < 5; i++ {
+				go func() {
+					for i := 0; i < 500000; i++ {
+						_ = s.AddEventsWithToken("HELLOOOOOO", evs)
+					}
+				}()
+			}
+			time.Sleep(500 * time.Millisecond) // wait half a second to start filling the buffer
+			So(errors.Details(s.Close()), ShouldContainSubstring, "may have been dropped")
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkCleanCloseDatapoints(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should gracefully shutdown after some datapoints are added to it", func() {
+			s := NewAsyncMultiTokenSink(int64(2), 5, 2500, "", "", "", newDefaultHTTPClient, nil)
+			dps := GoMetricsSource.Datapoints()
+			s.ShutdownTimeout = (time.Second * 5)
+
+			go func() {
+				for i := 0; i < 500000; i++ {
+					_ = s.AddDatapointsWithToken("HELLOOOOOO", dps)
+					_ = s.AddDatapointsWithToken("HELLOOOOOO2", dps)
+				}
+			}()
+
+			time.Sleep(500 * time.Millisecond) // wait half a second to start filling the buffer
+			So(s.Close(), ShouldBeNil)
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkCleanCloseEvents(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should gracefully shutdown after some events are added to it", func() {
+			s := NewAsyncMultiTokenSink(int64(2), 5, 2500, "", "", "", newDefaultHTTPClient, nil)
+			evs := GoEventSource.Events()
+			s.ShutdownTimeout = (time.Second * 5)
+
+			go func() {
+				for i := 0; i < 500000; i++ {
+					_ = s.AddEventsWithToken("HELLOOOOOO", evs)
+					_ = s.AddEventsWithToken("HELLOOOOOO2", evs)
+				}
+			}()
+
+			time.Sleep(500 * time.Millisecond) // wait half a second to start filling the buffer
+			So(s.Close(), ShouldBeNil)
+		})
+	})
+}
+
+func TestAsyncTokenStatusCounter(t *testing.T) {
+	s := NewAsyncTokenStatusCounter("testCounter", 5000, 1, map[string]string{"testdim1": "testdimval"})
+	wg := sync.WaitGroup{}
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			d := &tokenStatus{
+				status: http.StatusOK,
+				token:  "HELLOOO",
+				val:    5,
+			}
+			for i := 0; i < 5; i++ {
+				s.Increment(d)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	time.Sleep(1 * time.Second)
+	dps := s.Datapoints()
+	Convey("An AsyncTokenStatusMap should be able to accept simultaneous calls to Increment", t, func() {
+		So(dps, ShouldNotBeNil)
+		So(dps[0].Value.(datapoint.IntValue).Int(), ShouldEqual, 125)
+	})
+}
+
+func TestAsyncMultiTokenSinkCleanCloseDatapointsAndEvents(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should gracefully shutdown after some data is added to it", func() {
+			s := NewAsyncMultiTokenSink(int64(2), 5, 2500, "", "", "", newDefaultHTTPClient, nil)
+			dps := GoMetricsSource.Datapoints()
+			evs := GoEventSource.Events()
+			s.ShutdownTimeout = (time.Second * 5)
+
+			go func() {
+				for i := 0; i < 500000; i++ {
+					_ = s.AddDatapointsWithToken("HELLOOOOOO", dps)
+					_ = s.AddDatapointsWithToken("HELLOOOOOO2", dps)
+				}
+			}()
+
+			go func() {
+				for i := 0; i < 500000; i++ {
+					_ = s.AddEventsWithToken("HELLOOOOOO", evs)
+					_ = s.AddEventsWithToken("HELLOOOOOO2", evs)
+				}
+			}()
+
+			time.Sleep(500 * time.Millisecond) // wait half a second to start filling the buffer
+			So(s.Close(), ShouldBeNil)
+		})
+	})
+}
+
+func TestAsyncMultiTokenSinkHasherError(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+
+		dps := GoMetricsSource.Datapoints()
+		evs := GoEventSource.Events()
+
+		Convey("should not be able to add datapoints or events if the hasher is nil", func() {
+			s := NewAsyncMultiTokenSink(int64(3), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+			s.Hasher = nil
+			So(s.AddDatapointsWithToken("HELLOOOOOO", dps), ShouldNotBeNil)
+			So(s.AddEventsWithToken("HELLOOOOOO", evs), ShouldNotBeNil)
+		})
+		Convey("should not be able to add datapoints or events if there are no workers", func() {
+			s := NewAsyncMultiTokenSink(int64(0), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+			So(s.AddDatapointsWithToken("HELLOOOOOO", dps), ShouldNotBeNil)
+			So(s.AddEventsWithToken("HELLOOOOOO", evs), ShouldNotBeNil)
+		})
+	})
+}
+
+func processDpDropped(dp *datapoint.Datapoint) (dpDropped int64) {
+	if dp.Metric == "total_datapoints_by_token" {
+		for dim, val := range dp.Dimensions {
+			if dim == "status" && val != http.StatusText(http.StatusOK) {
+				dpDropped = dpDropped + dp.Value.(datapoint.IntValue).Int()
+			}
+		}
+	}
+	return
+}
+
+func processEvDropped(dp *datapoint.Datapoint) (evDropped int64) {
+	if dp.Metric == "total_events_by_token" {
+		for dim, val := range dp.Dimensions {
+			if dim == "status" && val != http.StatusText(http.StatusOK) {
+				evDropped = evDropped + dp.Value.(datapoint.IntValue).Int()
+			}
+		}
+	}
+	return
+}
+
+func processDpEmitted(dp *datapoint.Datapoint) (dpEmitted int64) {
+	if dp.Metric == "total_datapoints_by_token" {
+		for dim, val := range dp.Dimensions {
+			if dim == "status" && val == http.StatusText(http.StatusOK) {
+				dpEmitted = dpEmitted + dp.Value.(datapoint.IntValue).Int()
+			}
+		}
+	}
+	return
+}
+
+func processEvEmitted(dp *datapoint.Datapoint) (evEmitted int64) {
+	if dp.Metric == "total_events_by_token" {
+		for dim, val := range dp.Dimensions {
+			if dim == "status" && val == http.StatusText(http.StatusOK) {
+				evEmitted = evEmitted + dp.Value.(datapoint.IntValue).Int()
+			}
+		}
+	}
+	return
+}
+
+// ProcessDatapoints is a helper function for parsing out the datapoint values from an array of AsyncMultiTokenSink datapoints
+func ProcessDatapoints(data []*datapoint.Datapoint) (dpDropped int64, evDropped int64, dpEmitted int64, evEmitted int64) {
+	for _, dp := range data {
+		dpDropped = dpDropped + processDpDropped(dp)
+		evDropped = evDropped + processEvDropped(dp)
+		dpEmitted = dpEmitted + processDpEmitted(dp)
+		evEmitted = evEmitted + processEvEmitted(dp)
+	}
+	return
+}
+
+func TestAsyncMultiTokenSinkDatapoints(t *testing.T) {
+	Convey("An AsyncMultiTokenSink", t, func() {
+		Convey("should account for datapoints and events pushed through the sink", func() {
+			s := NewAsyncMultiTokenSink(int64(2), 5, 5000, "", "", "", newDefaultHTTPClient, nil)
+			dps := GoMetricsSource.Datapoints()
+			evs := GoEventSource.Events()
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, TokenCtxKey, "HELLOOOOOO")
+			s.ShutdownTimeout = time.Second * 5
+			data := s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			for _, d := range data {
+				t.Log(d)
+			}
+			var dpDropped, evDropped, dpEmitted, evEmitted = ProcessDatapoints(data)
+			So(dpDropped, ShouldEqual, datapoint.NewIntValue(0))
+			So(evDropped, ShouldEqual, datapoint.NewIntValue(0))
+			So(dpEmitted, ShouldEqual, datapoint.NewIntValue(0))
+			So(evEmitted, ShouldEqual, datapoint.NewIntValue(0))
+			t.Log("Adding events")
+			s.AddEvents(ctx, evs)
+			t.Log("Adding Datapoints")
+			s.AddDatapointsWithToken("HELLOOOOOO", dps)
+			time.Sleep(time.Second * 3)
+			data = s.Datapoints()
+			So(data, ShouldNotBeEmpty)
+			for _, d := range data {
+				t.Log(d)
+			}
+			dpDropped, evDropped, dpEmitted, evEmitted = ProcessDatapoints(data)
+			So(dpDropped, ShouldEqual, datapoint.NewIntValue(int64(len(dps))))
+			So(evDropped, ShouldEqual, datapoint.NewIntValue(int64(len(evs))))
+			So(dpEmitted, ShouldEqual, datapoint.NewIntValue(0))
+			So(evEmitted, ShouldEqual, datapoint.NewIntValue(0))
+			err := s.Close() // close to ensure that all of the datapoints and events are processed
+			data = s.Datapoints()
+			So(len(data), ShouldEqual, 2) // only the data buffered should be reported
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func BenchmarkAsyncMultiTokenSinkCreate(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	}
+}
+
+// Without TimeBuffer
+func BenchmarkAsyncMultiTokenSinkAddIndividualDatapoints(b *testing.B) {
+	points := GoMetricsSource.Datapoints()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	l := len(points)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < l; j++ {
+			var dp = make([]*datapoint.Datapoint, 0)
+			dp = append(dp, points[j])
+			_ = sink.AddDatapoints(ctx, dp)
+		}
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkAddSeveralDatapoints(b *testing.B) {
+	points := GoMetricsSource.Datapoints()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = sink.AddDatapoints(ctx, points)
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkAddIndividualEvents(b *testing.B) {
+	events := GoEventSource.Events()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	l := len(events)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < l; j++ {
+			var ev = make([]*event.Event, 0)
+			ev = append(ev, events[j])
+			_ = sink.AddEvents(ctx, ev)
+		}
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkAddSeveralEvents(b *testing.B) {
+	events := GoEventSource.Events()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = sink.AddEvents(ctx, events)
+	}
+}
+
+// With TimeBuffer
+func BenchmarkAsyncMultiTokenSinkWithBufferAddIndividualDatapoints(b *testing.B) {
+	points := GoMetricsSource.Datapoints()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	l := len(points)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < l; j++ {
+			var dp = make([]*datapoint.Datapoint, 0)
+			dp = append(dp, points[j])
+			_ = sink.AddDatapoints(ctx, dp)
+		}
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkWithBufferAddSeveralDatapoints(b *testing.B) {
+	points := GoMetricsSource.Datapoints()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = sink.AddDatapoints(ctx, points)
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkWithBufferAddIndividualEvents(b *testing.B) {
+	events := GoEventSource.Events()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	l := len(events)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < l; j++ {
+			var ev = make([]*event.Event, 0)
+			ev = append(ev, events[j])
+			_ = sink.AddEvents(ctx, ev)
+		}
+	}
+}
+
+func BenchmarkAsyncMultiTokenSinkWithBufferAddSeveralEvents(b *testing.B) {
+	events := GoEventSource.Events()
+	sink := NewAsyncMultiTokenSink(int64(1), 5, 30, "", "", "", newDefaultHTTPClient, nil)
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = sink.AddEvents(ctx, events)
+	}
+}


### PR DESCRIPTION
* Add reportSHA and clientcfg pkgs
* Add additional log keys
* Drop compatibility for golang v 1.4 (for dependency go-kit)
* Add additional go versions to travis and cirlceci
* Extend test timeout to 30 sec
* Fix CI scripts to use Thrift v0.9.3
* Ignore go vet error "unrecognized verb 'n'" found in sprintf statement
* Upgrade gobuild to v1.7
* Replace aligncheck gobuild config with maligned
