### PR TITLE
add response body on HTTP errors

### DIFF
--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -49,6 +49,16 @@ type HTTPSink struct {
 	}
 }
 
+// SFXAPIError is returned when the API returns a status code other than 200.
+type SFXAPIError struct {
+	StatusCode   int
+	ResponseBody string
+}
+
+func (se SFXAPIError) Error() string {
+	return fmt.Sprintf("invalid status code %d", se.StatusCode)
+}
+
 func (h *HTTPSink) handleResponse(resp *http.Response, respErr error) (err error) {
 	if respErr != nil {
 		return errors.Annotatef(respErr, "failed to send/recieve http request")
@@ -63,7 +73,10 @@ func (h *HTTPSink) handleResponse(resp *http.Response, respErr error) (err error
 		return errors.Annotate(err, "cannot fully read response body")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("invalid status code %d", resp.StatusCode)
+		return SFXAPIError{
+			StatusCode:   resp.StatusCode,
+			ResponseBody: string(respBody),
+		}
 	}
 	var bodyStr string
 	err = json.Unmarshal(respBody, &bodyStr)


### PR DESCRIPTION
This morning we started receiving a lot of `invalid status code: 400` errors, and it was difficult to debug. This PR adds the response body to the `error` returned when the API returns a non-200 status code.