### PR TITLE
Add AddEvents to sfxclient Sink

### DIFF
--- a/sfxclient/sfxclient.go
+++ b/sfxclient/sfxclient.go
@@ -59,6 +59,7 @@ import (
 	"expvar"
 
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
 
 	"sync"
 	"sync/atomic"
@@ -83,6 +84,7 @@ var DefaultErrorHandler = func(err error) error {
 // stubbing out your collector to test the points that will be sent to SignalFx.
 type Sink interface {
 	AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) (err error)
+	AddEvents(ctx context.Context, events []*event.Event) (err error)
 }
 
 // Collector is anything Scheduler can track that emits points


### PR DESCRIPTION
# Summary

Add `AddEvents` to `sfxclient.Sink`.

# Motivation

From what I can tell `sfxclient.Sink` is provided to allow folks to make a testable sink that doesn't send anything to SFx. The `Sink` however, does not include `AddEvents` so we can't test that bit. This seems like a reasonable solution.

# Other Notes

Seems like there could also be a type assertion added in sfxclient to ensure that sinks (`HTTPSink`, `AsyncMultiTokenSink`, etc) correctly implement `sfxclient.Sink` but I stopped short of that.

Thanks!