### PR TITLE
Add hyphen to allowed characters for dimension keys

### DIFF
--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -193,7 +193,7 @@ func filterSignalfxKey(str string) string {
 }
 
 func runeFilterMap(r rune) rune {
-	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' {
+	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' || r == '-' {
 		return r
 	}
 	return '_'


### PR DESCRIPTION
According to [the documentation](https://developers.signalfx.com/v2/reference#section-criteria-for-metric-and-dimension-names-and-values) hyphens are allowed in dimension keys, but the protobof encoding for HTTPClient disallows them. This modifies the allowed characters to include `-`.

cc @mdubbyap 