### PR TITLE
Use WithContext instead of Cancel for http requests

### DIFF
--- a/datapoint/dpsink/logfilter.go
+++ b/datapoint/dpsink/logfilter.go
@@ -150,12 +150,14 @@ func (f *ItemFlagger) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		err := json.NewDecoder(req.Body).Decode(&newDimensions)
 		if err != nil {
 			rw.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintf(rw, "Cannot decode request JSON: %s", err.Error())
+			_, err = fmt.Fprintf(rw, "Cannot decode request JSON: %s", err.Error())
+			log.IfErr(f.Logger, err)
 			return
 		}
 		log.IfErr(f.Logger, req.Body.Close())
 		f.SetDimensions(newDimensions)
-		fmt.Fprintf(rw, "Dimensions updated!")
+		_, err = fmt.Fprintf(rw, "Dimensions updated!")
+		log.IfErr(f.Logger, err)
 		return
 	}
 	if req.Method == "GET" {

--- a/expvar2/handler.go
+++ b/expvar2/handler.go
@@ -61,7 +61,8 @@ func (s filterSet) shouldFilter(search string) bool {
 }
 
 func (e *Handler) initialDump(w io.Writer, onlyFetch filterSet) {
-	fmt.Fprintf(w, "{")
+	_, err := fmt.Fprintf(w, "{")
+	log.IfErr(e.Logger, err)
 	first := true
 	usedKeys := map[string]struct{}{}
 	f := func(kv expvar.KeyValue) {
@@ -72,10 +73,12 @@ func (e *Handler) initialDump(w io.Writer, onlyFetch filterSet) {
 			return
 		}
 		if !first {
-			fmt.Fprintf(w, ",")
+			_, err = fmt.Fprintf(w, ",")
+			log.IfErr(e.Logger, err)
 		}
 		first = false
-		fmt.Fprintf(w, "%q:%s", kv.Key, kv.Value)
+		_, err = fmt.Fprintf(w, "%q:%s", kv.Key, kv.Value)
+		log.IfErr(e.Logger, err)
 	}
 	for k, v := range e.Exported {
 		f(expvar.KeyValue{
@@ -85,7 +88,8 @@ func (e *Handler) initialDump(w io.Writer, onlyFetch filterSet) {
 		usedKeys[k] = struct{}{}
 	}
 	expvar.Do(f)
-	fmt.Fprintf(w, "}")
+	_, err = fmt.Fprintf(w, "}")
+	log.IfErr(e.Logger, err)
 }
 
 func asSet(items []string) filterSet {

--- a/sfxclient/README.md
+++ b/sfxclient/README.md
@@ -280,8 +280,8 @@ type HTTPSink struct {
 	AuthToken          string
 	UserAgent          string
 	DatapointEndpoint  string
-    EventEndpoint      string
-	Client             http.Client
+	EventEndpoint      string
+	Client             *http.Client
 }
 ```
 

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -117,6 +117,7 @@ func (h *HTTPSink) doBottom(ctx context.Context, f func() (io.Reader, bool, erro
 	if err != nil {
 		return errors.Annotatef(err, "cannot parse new HTTP request to %s", endpoint)
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(TokenHeaderName, h.AuthToken)
 	req.Header.Set("User-Agent", h.UserAgent)
@@ -124,7 +125,6 @@ func (h *HTTPSink) doBottom(ctx context.Context, f func() (io.Reader, bool, erro
 	if compressed {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
-	req.Cancel = ctx.Done()
 	resp, err := h.Client.Do(req)
 	if err != nil {
 		// According to docs, resp can be ignored since err is non-nil, so we

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -55,7 +55,7 @@ type HTTPSink struct {
 	EventEndpoint      string
 	DatapointEndpoint  string
 	TraceEndpoint      string
-	Client             http.Client
+	Client             *http.Client
 	protoMarshaler     func(pb proto.Message) ([]byte, error)
 	jsonMarshal        func(v []*trace.Span) ([]byte, error)
 	DisableCompression bool
@@ -427,7 +427,7 @@ func NewHTTPSink() *HTTPSink {
 		DatapointEndpoint: IngestEndpointV2,
 		TraceEndpoint:     TraceIngestEndpointV1,
 		UserAgent:         DefaultUserAgent,
-		Client: http.Client{
+		Client: &http.Client{
 			Timeout: DefaultTimeout,
 		},
 		protoMarshaler: proto.Marshal,

--- a/sfxclient/httpsink_test.go
+++ b/sfxclient/httpsink_test.go
@@ -175,7 +175,7 @@ func TestHTTPDatapointSink(t *testing.T) {
 						cancelCallback()
 					}
 					select {
-					case <-req.Cancel:
+					case <-req.Context().Done():
 					case <-blockResponse:
 					}
 				}
@@ -277,7 +277,7 @@ func TestHTTPDatapointSink(t *testing.T) {
 			Convey("timeouts should work", func() {
 				blockResponse = make(chan struct{})
 				s.Client.Timeout = time.Millisecond * 10
-				So(errors.Details(s.AddDatapoints(ctx, dps)), ShouldContainSubstring, "Timeout exceeded")
+				So(errors.Details(s.AddDatapoints(ctx, dps)), ShouldContainSubstring, "Client.Timeout")
 			})
 			Reset(func() {
 				if blockResponse != nil {
@@ -397,7 +397,7 @@ func TestHTTPEventSink(t *testing.T) {
 						cancelCallback()
 					}
 					select {
-					case <-req.Cancel:
+					case <-req.Context().Done():
 					case <-blockResponse:
 					}
 				}
@@ -485,7 +485,7 @@ func TestHTTPEventSink(t *testing.T) {
 			Convey("timeouts should work", func() {
 				blockResponse = make(chan struct{})
 				s.Client.Timeout = time.Millisecond * 10
-				So(errors.Details(s.AddEvents(ctx, dps)), ShouldContainSubstring, "Timeout exceeded")
+				So(errors.Details(s.AddEvents(ctx, dps)), ShouldContainSubstring, "Client.Timeout")
 			})
 			Reset(func() {
 				if blockResponse != nil {

--- a/sfxclient/multitokensink.go
+++ b/sfxclient/multitokensink.go
@@ -463,7 +463,7 @@ type AsyncMultiTokenSink struct {
 	evChannels    []*evChannel              // evChannels is an array of evChannels used to emit events asynchronously
 	dpBuffered    int64                     // number of datapoints in the sink that haven't been emitted
 	evBuffered    int64                     // number of events in the sink that haven't been emitted
-	NewHTTPClient func() http.Client        // function used to create an http client for the underlying sinks
+	NewHTTPClient func() *http.Client       // function used to create an http client for the underlying sinks
 	stats         *asyncMultiTokenSinkStats //stats are stats about that sink that can be collected from the Datapoitns() method
 	maxRetry      int                       // maximum number of times to retry sending a set of datapoints or events
 }
@@ -628,8 +628,8 @@ func (a *AsyncMultiTokenSink) Close() (err error) {
 }
 
 // newDefaultHTTPClient returns a default http client for the sink
-func newDefaultHTTPClient() http.Client {
-	return http.Client{
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{
 		Timeout: DefaultTimeout,
 	}
 }
@@ -646,7 +646,7 @@ type evChannel struct {
 	workers []*eventWorker
 }
 
-func newDPChannel(numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() http.Client, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool, maxRetry int) (dpc *dpChannel) {
+func newDPChannel(numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() *http.Client, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool, maxRetry int) (dpc *dpChannel) {
 	dpc = &dpChannel{
 		input:   make(chan *dpMsg, int64(buffer)),
 		workers: make([]*datapointWorker, numDrainingThreads),
@@ -667,7 +667,7 @@ func newDPChannel(numDrainingThreads int64, buffer int, batchSize int, Datapoint
 	return
 }
 
-func newEVChannel(numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() http.Client, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool, maxRetry int) (evc *evChannel) {
+func newEVChannel(numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() *http.Client, errorHandler func(error) error, stats *asyncMultiTokenSinkStats, closing chan bool, done chan bool, maxRetry int) (evc *evChannel) {
 	evc = &evChannel{
 		input:   make(chan *evMsg, int64(buffer)),
 		workers: make([]*eventWorker, numDrainingThreads),
@@ -689,7 +689,7 @@ func newEVChannel(numDrainingThreads int64, buffer int, batchSize int, Datapoint
 }
 
 // NewAsyncMultiTokenSink returns a sink that asynchronously emits datapoints with different tokens
-func NewAsyncMultiTokenSink(numChannels int64, numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() http.Client, errorHandler func(error) error, maxRetry int) *AsyncMultiTokenSink {
+func NewAsyncMultiTokenSink(numChannels int64, numDrainingThreads int64, buffer int, batchSize int, DatapointEndpoint string, EventEndpoint string, userAgent string, httpClient func() *http.Client, errorHandler func(error) error, maxRetry int) *AsyncMultiTokenSink {
 	a := &AsyncMultiTokenSink{
 		ShutdownTimeout: time.Second * 5,
 		errorHandler:    DefaultErrorHandler,


### PR DESCRIPTION
The current code pulls out the `ctx.Done` function to handle request timeouts, but doesn't attach the context to the request itself. This gets in the way of things like net/http/httptrace. Instead, we should be using `WithContext`, which handles timeouts, and also exposes the context to other stuff. [This](https://github.com/stripe/veneur/commit/71e9438a7e5b015a2feb5f6f67168712ec7cd948) is a concrete example of why the context needs to be attached to the request.

The `*http.Client` change is mostly for hygiene (clients should usually be shared), but I can remove that commit if maintainers prefer.