### PR TITLE
removing 'Property' attribute from Datapoint.

### DIFF
--- a/datapoint/datapoint.go
+++ b/datapoint/datapoint.go
@@ -21,7 +21,7 @@ const (
 	// Count is a number per a given interval (such as a statsd flushInterval); not very useful
 	Count
 	// Enum is an added type: Values aren't important relative to each other but are just important as distinct
-	//             items in a set.  Usually used when Value is type "string"
+	// items in a set.  Usually used when Value is type "string"
 	Enum
 	// Counter is a number that keeps increasing over time (but might wrap/reset at some points)
 	// (no statsd counterpart), i.e. a gauge with the added notion of "i usually want to derive this"
@@ -88,39 +88,6 @@ func (dp *Datapoint) UnmarshalJSON(b []byte) error {
 
 func (dp *Datapoint) String() string {
 	return fmt.Sprintf("DP[%s\t%s\t%s\t%d\t%s]", dp.Metric, dp.Dimensions, dp.Value, dp.MetricType, dp.Timestamp.String())
-}
-
-type metadata int
-
-const (
-	tsProperty metadata = iota
-)
-
-//SetProperty sets a property to be used when the time series associated with the datapoint is created
-func (dp *Datapoint) SetProperty(key string, value interface{}) {
-	if dp.Meta[tsProperty] == nil {
-		dp.Meta[tsProperty] = make(map[string]interface{}, 1)
-	}
-	dp.GetProperties()[key] = value
-}
-
-//RemoveProperty removes a property from the map of properties to be used when the time series associated with the datapoint is created
-func (dp *Datapoint) RemoveProperty(key string) {
-	if dp.Meta[tsProperty] != nil {
-		delete(dp.GetProperties(), key)
-		if len(dp.GetProperties()) == 0 {
-			delete(dp.Meta, tsProperty)
-		}
-	}
-}
-
-//GetProperties gets the map of properties to set when creating the time series associated with the datapoint. nil if no properties are set.
-func (dp *Datapoint) GetProperties() map[string]interface{} {
-	m, ok := dp.Meta[tsProperty].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	return m
 }
 
 // New creates a new datapoint with empty meta data

--- a/datapoint/datapoint_test.go
+++ b/datapoint/datapoint_test.go
@@ -1,10 +1,9 @@
 package datapoint
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
-
-	"encoding/json"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -64,34 +63,5 @@ func TestAddDatapoints(t *testing.T) {
 		So(AddMaps(m1, nil), ShouldEqual, m1)
 		So(AddMaps(nil, m2), ShouldEqual, m2)
 		So(AddMaps(m1, m2)["name"], ShouldEqual, "john")
-	})
-}
-
-func TestDatapointProperties(t *testing.T) {
-	Convey("Given a datapoint", t, func() {
-		dp := New("datapoint", map[string]string{}, NewIntValue(10), Gauge, time.Now())
-		Convey("GetProperties should return nil", func() {
-			So(dp.GetProperties(), ShouldBeNil)
-		})
-
-		Convey("When you add a key value", func() {
-			dp.SetProperty("foo", "bar")
-			Convey("GetProperties should return map with key value", func() {
-				So(dp.GetProperties(), ShouldResemble, map[string]interface{}{"foo": "bar"})
-			})
-			Convey("and then remove it", func() {
-				dp.RemoveProperty("foo")
-				Convey("GetProperties should return nil", func() {
-					So(dp.GetProperties(), ShouldBeNil)
-				})
-			})
-		})
-
-		Convey("When You remove a missing key", func() {
-			dp.RemoveProperty("foo1")
-			Convey("GetProperties should return nil", func() {
-				So(dp.GetProperties(), ShouldBeNil)
-			})
-		})
 	})
 }

--- a/datapoint/dpsink/logfilter.go
+++ b/datapoint/dpsink/logfilter.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
-	"github.com/signalfx/golib/datapoint"
-	"github.com/signalfx/golib/event"
-	"github.com/signalfx/golib/log"
-	"github.com/signalfx/golib/trace"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/trace"
 )
 
 // FlagCheck checks a context to see if a debug flag is set

--- a/datapoint/dpsink/logfilter_test.go
+++ b/datapoint/dpsink/logfilter_test.go
@@ -1,13 +1,13 @@
 package dpsink
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
-	"context"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/event"
 	"github.com/signalfx/golib/log"

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -2,20 +2,20 @@ package sfxclient
 
 import (
 	"bytes"
+	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode"
-
-	"compress/gzip"
-	"context"
-	"io"
-	"sync"
+	"unsafe"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/mailru/easyjson"
@@ -26,7 +26,6 @@ import (
 	"github.com/signalfx/golib/sfxclient/spanfilter"
 	"github.com/signalfx/golib/trace"
 	"github.com/signalfx/golib/trace/format"
-	"unsafe"
 )
 
 const (
@@ -277,16 +276,6 @@ func (h *HTTPSink) coreDatapointToProtobuf(point *datapoint.Datapoint) *com_sign
 		Value:      datumForPoint(point.Value),
 		MetricType: &mt,
 		Dimensions: mapToDimensions(point.Dimensions),
-	}
-	for k, v := range point.GetProperties() {
-		kv := k
-		pv := rawToProtobuf(v)
-		if pv != nil && k != "" {
-			dp.Properties = append(dp.Properties, &com_signalfx_metrics_protobuf.Property{
-				Key:   &kv,
-				Value: pv,
-			})
-		}
 	}
 	return dp
 }


### PR DESCRIPTION
summary: 'Property' attribute in Datapoint was experimental and never
supported. The commit will remove support for the same.

test: ran all unit test cases & removed any test case which was handling
property