### PR TITLE
make env package functions return copies of their pointed default values

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -12,7 +12,14 @@ func GetStringEnvVar(envVar string, def *string) *string {
 	if val := os.Getenv(envVar); val != "" {
 		return &val
 	}
-	return def
+
+	// return a copy of the default
+	if def != nil {
+		ret := *def
+		return &ret
+	}
+
+	return nil
 }
 
 // GetDurationEnvVar returns the given env var key's value as a Duration or the default value
@@ -22,7 +29,14 @@ func GetDurationEnvVar(envVar string, def *time.Duration) *time.Duration {
 			return &dur
 		}
 	}
-	return def
+
+	// return a copy of the default
+	if def != nil {
+		ret := *def
+		return &ret
+	}
+
+	return nil
 }
 
 // GetUintEnvVar returns the given env var key's value as a uint or the default value
@@ -33,7 +47,14 @@ func GetUintEnvVar(envVar string, def *uint) *uint {
 			return &val
 		}
 	}
-	return def
+
+	// return a copy of the default
+	if def != nil {
+		ret := *def
+		return &ret
+	}
+
+	return nil
 }
 
 // GetUint64EnvVar returns the given env var key's value as a uint64 or the default value
@@ -43,16 +64,27 @@ func GetUint64EnvVar(envVar string, def *uint64) *uint64 {
 			return &parsedVal
 		}
 	}
-	return def
+
+	// return a copy of the default
+	if def != nil {
+		ret := *def
+		return &ret
+	}
+
+	return nil
 }
 
 // GetCommaSeparatedStringEnvVar returns the given env var key's value split by comma or the default values
 func GetCommaSeparatedStringEnvVar(envVar string, def []string) []string {
 	if val := os.Getenv(envVar); val != "" {
-		def = def[:0]
-		for _, addr := range strings.Split(strings.Replace(val, " ", "", -1), ",") {
-			def = append(def, addr)
-		}
+		return strings.Split(strings.Replace(val, " ", "", -1), ",")
 	}
-	return def
+
+	// return a copy of the default
+	var ret = make([]string, len(def))
+	for i, s := range def {
+		ret[i] = s
+	}
+
+	return ret
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -21,8 +21,14 @@ func TestGetStringEnvVar(t *testing.T) {
 			convey.So(*loaded, convey.ShouldEqual, testVal)
 		})
 		convey.Convey("should return the default value if the environment variable is not set", func() {
-			loaded := GetStringEnvVar(testKey, pointer.String("defaultVal"))
+			testVal := pointer.String("defaultVal")
+			loaded := GetStringEnvVar(testKey, testVal)
+			convey.So(loaded, convey.ShouldNotEqual, testVal)
 			convey.So(*loaded, convey.ShouldEqual, "defaultVal")
+		})
+		convey.Convey("should return nil if the default value is nil and the environment variable is not set", func() {
+			loaded := GetStringEnvVar(testKey, nil)
+			convey.So(loaded, convey.ShouldEqual, nil)
 		})
 		convey.Reset(func() {
 			os.Unsetenv(testKey)
@@ -39,8 +45,14 @@ func TestGetDurationEnvVar(t *testing.T) {
 			convey.So(*loaded, convey.ShouldEqual, time.Second*5)
 		})
 		convey.Convey("should return the default value if the environment variable is not set", func() {
-			loaded := GetDurationEnvVar(testKey, pointer.Duration(1*time.Second))
+			testVal := pointer.Duration(1 * time.Second)
+			loaded := GetDurationEnvVar(testKey, testVal)
+			convey.So(loaded, convey.ShouldNotEqual, testVal)
 			convey.So(*loaded, convey.ShouldEqual, time.Second*1)
+		})
+		convey.Convey("should return nil if the default value is nil and the environment variable is not set", func() {
+			loaded := GetDurationEnvVar(testKey, nil)
+			convey.So(loaded, convey.ShouldEqual, nil)
 		})
 		convey.Reset(func() {
 			os.Unsetenv(testKey)
@@ -57,8 +69,14 @@ func TestGetUint64EnvVar(t *testing.T) {
 			convey.So(*loaded, convey.ShouldEqual, 5)
 		})
 		convey.Convey("should return the default value if the environment variable is not set", func() {
-			loaded := GetUint64EnvVar(testKey, pointer.Uint64(1))
+			testVal := pointer.Uint64(1)
+			loaded := GetUint64EnvVar(testKey, testVal)
+			convey.So(loaded, convey.ShouldNotEqual, testVal)
 			convey.So(*loaded, convey.ShouldEqual, 1)
+		})
+		convey.Convey("should return nil if the default value is nil and the environment variable is not set", func() {
+			loaded := GetUint64EnvVar(testKey, nil)
+			convey.So(loaded, convey.ShouldEqual, nil)
 		})
 		convey.Reset(func() {
 			os.Unsetenv(testKey)
@@ -75,8 +93,14 @@ func TestGetUintEnvVar(t *testing.T) {
 			convey.So(*loaded, convey.ShouldEqual, 10)
 		})
 		convey.Convey("should return the default value if the environment variable is not set", func() {
-			loaded := GetUintEnvVar(testKey, pointer.Uint(1))
+			testVal := pointer.Uint(1)
+			loaded := GetUintEnvVar(testKey, testVal)
+			convey.So(loaded, convey.ShouldNotEqual, testVal)
 			convey.So(*loaded, convey.ShouldEqual, 1)
+		})
+		convey.Convey("should return nil if the default value is nil and the environment variable is not set", func() {
+			loaded := GetUintEnvVar(testKey, nil)
+			convey.So(loaded, convey.ShouldEqual, nil)
 		})
 		convey.Reset(func() {
 			os.Unsetenv(testKey)


### PR DESCRIPTION
I think there is benefit to keeping the default argument as a pointer.  Specifically in the gateway, where we are passing in a pointer to a loaded config value which may or may not be nil.

I do think that these functions shouldn't blindly return the default argument as is.  Instead they should return a pointer to a copy of the default argument's value.  Hopefully this will help reduce confusion since the functions are returning pointers to values, instead of setting the value at a specified pointer.