### PR TITLE
logkey: changing DiscoService value to "disco_service"

### DIFF
--- a/logkey/keys.go
+++ b/logkey/keys.go
@@ -31,7 +31,7 @@ var (
 	DistconfNewVal = log.Key("distconf_newval")
 
 	// DiscoService is the name of a service in disco
-	DiscoService = log.Key("service")
+	DiscoService = log.Key("dicso_service")
 	// DiscoNode is the name of an ephemeral node in disco
 	DiscoNode = log.Key("node")
 	// GUID is the ID attached to a disco advertiser


### PR DESCRIPTION
when a service is using disco package it passes DiscoService name which
ended up overwriting context service value to DiscoService.