### PR TITLE
Fix downstream counter count

### DIFF
--- a/datapoint/dpsink/counter.go
+++ b/datapoint/dpsink/counter.go
@@ -118,7 +118,11 @@ func (c *Counter) AddSpans(ctx context.Context, spans []*trace.Span, next trace.
 	atomic.AddInt64(&c.CallsInFlight, -1)
 	if err != nil && spanfilter.IsInvalid(err) {
 		atomic.AddInt64(&c.TotalProcessErrors, 1)
-		atomic.AddInt64(&c.ProcessErrorSpans, int64(len(spans)))
+		if m, ok := err.(*spanfilter.Map); ok {
+			atomic.AddInt64(&c.ProcessErrorSpans, int64(len(m.Invalid)))
+		} else {
+			atomic.AddInt64(&c.ProcessErrorSpans, int64(len(spans)))
+		}
 		c.logErrMsg(ctx, err, "Unable to process spans")
 	}
 	return err

--- a/datapoint/dpsink/counter_test.go
+++ b/datapoint/dpsink/counter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/signalfx/golib/event"
 	"github.com/signalfx/golib/log"
 	"github.com/signalfx/golib/logkey"
+	"github.com/signalfx/golib/sfxclient/spanfilter"
 	"github.com/signalfx/golib/trace"
 	"github.com/stretchr/testify/assert"
 )
@@ -115,4 +116,13 @@ func TestCounterSinkTrace(t *testing.T) {
 		t.Fatal("Expected an error!")
 	}
 	assert.Equal(t, int64(1), atomic.LoadInt64(&count.TotalProcessErrors), "Error should be sent through")
+	assert.Equal(t, int64(2), atomic.LoadInt64(&count.ProcessErrorSpans), "Num should be 2")
+	m := &spanfilter.Map{}
+	m.Add("blarg", "foo")
+	bs.RetError(m)
+	if err := middleSink.AddSpans(ctx, es); err == nil {
+		t.Fatal("Expected an error!")
+	}
+	assert.Equal(t, int64(2), atomic.LoadInt64(&count.TotalProcessErrors), "Error should be sent through")
+	assert.Equal(t, int64(3), atomic.LoadInt64(&count.ProcessErrorSpans), "Num should be one more")
 }


### PR DESCRIPTION
When a spanfilter is returned we were still counting the full # of spans in the payload, not just the invalid number that was returned in the spanfilter.