### PR TITLE
make scheduler.CollectDatapoints() lock the callback mutex

### DIFF
--- a/sfxclient/sfxclient.go
+++ b/sfxclient/sfxclient.go
@@ -206,8 +206,15 @@ func (s *Scheduler) Var() expvar.Var {
 	})
 }
 
-// CollectDatapoints gives a scheduler an external endpoint to be called
+// CollectDatapoints gives a scheduler an external endpoint to be called and is thread safe
 func (s *Scheduler) CollectDatapoints() []*datapoint.Datapoint {
+	s.callbackMutex.Lock()
+	defer s.callbackMutex.Unlock()
+	return s.collectDatapoints()
+}
+
+// collectDatapoints gives a scheduler an external endpoint to be called and is not thread safe
+func (s *Scheduler) collectDatapoints() []*datapoint.Datapoint {
 	ret := make([]*datapoint.Datapoint, 0, len(s.previousDatapoints))
 	now := s.Timer.Now()
 	if s.debug {
@@ -288,7 +295,7 @@ func (s *Scheduler) ReportOnce(ctx context.Context) error {
 	datapoints := func() []*datapoint.Datapoint {
 		s.callbackMutex.Lock()
 		defer s.callbackMutex.Unlock()
-		datapoints := s.CollectDatapoints()
+		datapoints := s.collectDatapoints()
 		s.previousDatapoints = datapoints
 		return datapoints
 	}()
@@ -318,7 +325,7 @@ func (s *Scheduler) ReportingTimeout(timeout time.Duration) {
 	atomic.StoreInt64(&s.ReportingTimeoutNs, timeout.Nanoseconds())
 }
 
-// Debug used for debugging CollectDatapoints()
+// Debug used for debugging collectDatapoints()
 func (s *Scheduler) Debug(debug bool) {
 	s.debug = debug
 }

--- a/sfxclient/sfxclient_test.go
+++ b/sfxclient/sfxclient_test.go
@@ -198,6 +198,7 @@ func TestNewScheduler(t *testing.T) {
 			So(len(cf.Datapoints()), ShouldEqual, 0)
 			So(c, ShouldEqual, 1)
 			s.AddCallback(cf)
+			So(len(s.CollectDatapoints()), ShouldEqual, 0)
 		})
 
 		Convey("callbacks should be removable", func() {


### PR DESCRIPTION
We're using this CollectDatapoints() function in the gateway's internal metrics listener.  I just ran some tests with the go race detector and it detected a data race around our use of scheduler.CollectDatapoints().  This pr addresses that.