### PR TITLE
prefix datapoints in scheduler.CollectDatapoints

### DIFF
--- a/sfxclient/sfxclient.go
+++ b/sfxclient/sfxclient.go
@@ -210,7 +210,9 @@ func (s *Scheduler) Var() expvar.Var {
 func (s *Scheduler) CollectDatapoints() []*datapoint.Datapoint {
 	s.callbackMutex.Lock()
 	defer s.callbackMutex.Unlock()
-	return s.collectDatapoints()
+	datapoints := s.collectDatapoints()
+	s.prependPrefix(datapoints)
+	return datapoints
 }
 
 // collectDatapoints gives a scheduler an external endpoint to be called and is not thread safe


### PR DESCRIPTION
scheduler.ReportOnce prefixes datapoints with a configured prefix.  This pr makes scheduler.CollectDatapoints() also prefix datapoints for consistent behavior.