### PR TITLE
Increase CPU metadata query to 10 seconds from default of 3

### DIFF
--- a/metadata/hostmetadata/host.go
+++ b/metadata/hostmetadata/host.go
@@ -2,12 +2,14 @@ package hostmetadata
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -24,10 +26,12 @@ var HostEtc = func() string {
 	return "/etc"
 }
 
+const cpuTimeout = 10 * time.Second
+
 // Map library functions to unexported package variables for testing purposes.
 // It would be great if we could patch this somehow
-var cpuInfo = cpu.Info
-var cpuCounts = cpu.Counts
+var cpuInfo = cpu.InfoWithContext
+var cpuCounts = cpu.CountsWithContext
 var memVirtualMemory = mem.VirtualMemory
 var hostInfo = host.Info
 
@@ -59,14 +63,19 @@ func GetCPU() (info *CPU, err error) {
 
 	// get physical cpu stats
 	var cpus []cpu.InfoStat
-	if cpus, err = cpuInfo(); err != nil {
+
+	// On Windows this can sometimes take longer than the default timeout (3 seconds).
+	ctx, _ := context.WithTimeout(context.Background(), cpuTimeout)
+	if cpus, err = cpuInfo(ctx); err != nil {
 		return info, err
 	}
 
 	info.HostPhysicalCPUs = len(cpus)
 
+	ctx, _ = context.WithTimeout(context.Background(), cpuTimeout)
+
 	// get logical cpu stats
-	if info.HostLogicalCPUs, err = cpuCounts(true); err != nil {
+	if info.HostLogicalCPUs, err = cpuCounts(ctx, true); err != nil {
 		return info, err
 	}
 

--- a/metadata/hostmetadata/host.go
+++ b/metadata/hostmetadata/host.go
@@ -65,14 +65,14 @@ func GetCPU() (info *CPU, err error) {
 	var cpus []cpu.InfoStat
 
 	// On Windows this can sometimes take longer than the default timeout (3 seconds).
-	ctx, _ := context.WithTimeout(context.Background(), cpuTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cpuTimeout)
+	defer cancel()
+
 	if cpus, err = cpuInfo(ctx); err != nil {
 		return info, err
 	}
 
 	info.HostPhysicalCPUs = len(cpus)
-
-	ctx, _ = context.WithTimeout(context.Background(), cpuTimeout)
 
 	// get logical cpu stats
 	if info.HostLogicalCPUs, err = cpuCounts(ctx, true); err != nil {

--- a/metadata/hostmetadata/host_test.go
+++ b/metadata/hostmetadata/host_test.go
@@ -1,6 +1,7 @@
 package hostmetadata
 
 import (
+	"context"
 	"errors"
 	"os"
 	"reflect"
@@ -14,8 +15,8 @@ import (
 
 func TestGetCPU(t *testing.T) {
 	type testfixture struct {
-		cpuInfo   func() ([]cpu.InfoStat, error)
-		cpuCounts func(bool) (int, error)
+		cpuInfo   func(context.Context) ([]cpu.InfoStat, error)
+		cpuCounts func(context.Context, bool) (int, error)
 	}
 	tests := []struct {
 		name     string
@@ -26,7 +27,7 @@ func TestGetCPU(t *testing.T) {
 		{
 			name: "successful host cpu info",
 			fixtures: testfixture{
-				cpuInfo: func() ([]cpu.InfoStat, error) {
+				cpuInfo: func(ctx context.Context) ([]cpu.InfoStat, error) {
 					return []cpu.InfoStat{
 						{
 							ModelName: "testmodelname",
@@ -38,7 +39,7 @@ func TestGetCPU(t *testing.T) {
 						},
 					}, nil
 				},
-				cpuCounts: func(bool) (int, error) {
+				cpuCounts: func(context.Context, bool) (int, error) {
 					return 2, nil
 				},
 			},
@@ -52,7 +53,7 @@ func TestGetCPU(t *testing.T) {
 		{
 			name: "unsuccessful host cpu info (missing cpu info)",
 			fixtures: testfixture{
-				cpuInfo: func() ([]cpu.InfoStat, error) {
+				cpuInfo: func(context.Context) ([]cpu.InfoStat, error) {
 					return nil, errors.New("bad cpu info")
 				},
 			},
@@ -67,7 +68,7 @@ func TestGetCPU(t *testing.T) {
 		{
 			name: "unsuccessful host cpu info (missing cpu counts)",
 			fixtures: testfixture{
-				cpuInfo: func() ([]cpu.InfoStat, error) {
+				cpuInfo: func(context.Context) ([]cpu.InfoStat, error) {
 					return []cpu.InfoStat{
 						{
 							ModelName: "testmodelname",
@@ -79,7 +80,7 @@ func TestGetCPU(t *testing.T) {
 						},
 					}, nil
 				},
-				cpuCounts: func(bool) (int, error) {
+				cpuCounts: func(context.Context, bool) (int, error) {
 					return 0, errors.New("bad cpu counts")
 				},
 			},


### PR DESCRIPTION
WMI is sometimes slow on Windows and a box was observed taking 4 seconds to
return instead of the library default of 3.

As a first pass I've just made it a default timeout of 10 for everything for
CPU metadata. I could limit this to just apply to Windows or I could add a new
API that takes context in and punt the decision to the caller (in this case
it will be the sfx agent). Anybody have an opinion?