### PR TITLE
Revert "make log.IfErr (and friends) fetch the dynamic keys so log.Ca…

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -138,18 +138,14 @@ func (f LoggerFunc) Log(keyvals ...interface{}) {
 // IfErr is a shorthand that will log an error if err is not nil
 func IfErr(l Logger, err error) {
 	if err != nil {
-		if logCtx := NewContext(l); logCtx != nil && !IsDisabled(logCtx) {
-			logCtx.Logger.Log(addArrays(copyIfDynamic(logCtx.KeyVals), []interface{}{err})...)
-		}
+		l.Log(Err, err)
 	}
 }
 
 // IfErrAndReturn is a shorthand that will log an error if err is not nil and returns the original err
 func IfErrAndReturn(l Logger, err error) error {
 	if err != nil {
-		if logCtx := NewContext(l); logCtx != nil && !IsDisabled(logCtx) {
-			logCtx.Logger.Log(addArrays(copyIfDynamic(logCtx.KeyVals), []interface{}{err})...)
-		}
+		l.Log(Err, err)
 	}
 	return err
 }
@@ -157,20 +153,16 @@ func IfErrAndReturn(l Logger, err error) error {
 // IfErrWithKeys logs an error with the supplied logger if it is not nil.
 // The error will be appended to the end of the supplied keys/messages
 func IfErrWithKeys(l Logger, err error, intf ...interface{}) {
-	if err != nil {
-		if logCtx := NewContext(l); logCtx != nil && !IsDisabled(logCtx) {
-			logCtx.Logger.Log(addArrays(copyIfDynamic(logCtx.KeyVals), addArrays(intf, []interface{}{err}))...)
-		}
+	if err != nil && l != nil {
+		l.Log(append(intf, err)...)
 	}
 }
 
 // IfErrWithKeysAndReturn logs an error with the supplied logger if it is not nil and then returns the original error.
 // The error will be appended to the end of the supplied keys/messages
 func IfErrWithKeysAndReturn(l Logger, err error, intf ...interface{}) error {
-	if err != nil {
-		if logCtx := NewContext(l); logCtx != nil && !IsDisabled(logCtx) {
-			logCtx.Logger.Log(addArrays(copyIfDynamic(logCtx.KeyVals), addArrays(intf, []interface{}{err}))...)
-		}
+	if err != nil && l != nil {
+		l.Log(append(intf, err)...)
 	}
 	return err
 }


### PR DESCRIPTION
…ller is correct (#159)"

This reverts commit 99f26f0687efb802198f1d8d868f7459e912ec9f.

Realized that it really only fixes for one type of logger.  Will revert for now until I can think of a better solution.  Unfortunately I think the best solution will require modifying the Logger interface.