### PR TITLE
golib: add staging db to tsid cache

### DIFF
--- a/boltcycle/boltcycle.go
+++ b/boltcycle/boltcycle.go
@@ -54,6 +54,7 @@ type Stats struct {
 	TotalWriteCount               int64
 	TotalDeleteCount              int64
 	TotalCycleCount               int64
+	TotalEndCacheStagingCount     int64
 	TotalErrorsDuringRecopy       int64
 	TotalReadMovementsSkipped     int64
 	TotalReadMovementsAdded       int64

--- a/pdbcycle/pdbcycle_test.go
+++ b/pdbcycle/pdbcycle_test.go
@@ -92,6 +92,7 @@ func TestDataRaces(t *testing.T) {
 			AsyncErrors(myErrs),
 			InitDB(true),
 		)
+		pdb.EndCacheStaging()
 		So(err, ShouldBeNil)
 		wg := &sync.WaitGroup{}
 		wg.Add(4)
@@ -103,6 +104,21 @@ func TestDataRaces(t *testing.T) {
 		<-time.After(time.Second * 5)
 		close(closeChan)
 		wg.Wait()
+	})
+}
+
+func TestEndCacheStaging(t *testing.T) {
+	Convey("test without ending cache staging", t, func() {
+		dir, err := ioutil.TempDir(os.TempDir(), "pdbcycle")
+		Print("Temp directory used: " + dir + " ")
+		So(err, ShouldBeNil)
+		pdb, err := New(dir,
+			InitDB(true),
+		)
+		So(err, ShouldBeNil)
+		So(len(pdb.blobs.dbs), ShouldBeZeroValue)
+		pdb.EndCacheStaging()
+		So(len(pdb.blobs.dbs), ShouldEqual, 1)
 	})
 }
 
@@ -122,6 +138,7 @@ func Test(t *testing.T) {
 			MaxBatchSize(3),
 			InitDB(true),
 		)
+		pdb.EndCacheStaging()
 		So(err, ShouldBeNil)
 		So(pdb, ShouldNotBeNil)
 		Convey("test normal use", func() {
@@ -136,6 +153,7 @@ func Test(t *testing.T) {
 				So(len(data), ShouldEqual, 1)
 				So(string(data[0]), ShouldEqual, "firstdata")
 				So(pdb.CycleNodes(), ShouldBeNil)
+				pdb.EndCacheStaging()
 				infos, err := ioutil.ReadDir(dir)
 				So(err, ShouldBeNil)
 				So(len(infos), ShouldEqual, 2)
@@ -143,6 +161,7 @@ func Test(t *testing.T) {
 					err = pdb.Write([]boltcycle.KvPair{{Key: []byte("second"), Value: []byte("seconddata")}})
 					So(err, ShouldBeNil)
 					So(pdb.CycleNodes(), ShouldBeNil)
+					pdb.EndCacheStaging()
 					infos, err = ioutil.ReadDir(dir)
 					So(err, ShouldBeNil)
 					So(len(infos), ShouldEqual, 3)
@@ -155,6 +174,7 @@ func Test(t *testing.T) {
 							err = pdb.Write([]boltcycle.KvPair{{Key: []byte("third"), Value: []byte("thirddata")}})
 							So(err, ShouldBeNil)
 							So(pdb.CycleNodes(), ShouldBeNil)
+							pdb.EndCacheStaging()
 							infos, err = ioutil.ReadDir(dir)
 							So(err, ShouldBeNil)
 							So(len(infos), ShouldEqual, 3)
@@ -276,6 +296,7 @@ func TestErr(t *testing.T) {
 			So(err, ShouldBeNil)
 			myErrs := make(chan error)
 			pdb, err := New(dir, AsyncErrors(myErrs))
+			pdb.EndCacheStaging()
 			So(err, ShouldBeNil)
 
 			err = pdb.blobs.latest().Update(func(tx *bolt.Tx) error {
@@ -312,6 +333,7 @@ func TestErr(t *testing.T) {
 			So(err, ShouldBeNil)
 			myErrs := make(chan error, 10)
 			pdb, err := New(dir, AsyncErrors(myErrs))
+			pdb.EndCacheStaging()
 			So(err, ShouldBeNil)
 			pdb.AsyncWrite(context.Background(), []boltcycle.KvPair{{Key: []byte(""), Value: []byte("blargdata")}})
 			time.Sleep(time.Second)
@@ -320,6 +342,7 @@ func TestErr(t *testing.T) {
 			dir, err := ioutil.TempDir(os.TempDir(), "pdbcycle")
 			So(err, ShouldBeNil)
 			pdb, err := New(dir, ReadMovementBacklog(0))
+			pdb.EndCacheStaging()
 			So(err, ShouldBeNil)
 			So(pdb.Write([]boltcycle.KvPair{
 				{Key: []byte("blarg1"), Value: []byte("blargdata")},
@@ -330,6 +353,7 @@ func TestErr(t *testing.T) {
 			}), ShouldBeNil)
 			for pdb.Stats().TotalReadMovementsSkipped == 0 {
 				So(pdb.CycleNodes(), ShouldBeNil)
+				pdb.EndCacheStaging()
 				_, err = pdb.Read([][]byte{
 					[]byte("blarg1"),
 					[]byte("blarg2"),


### PR DESCRIPTION
Add staging bucket to tsid cache when CycleNodes() is called.
Staging bucket will be added to the slice of buckets when
EndCacheStaging() is called, which is on expiration of timer after
CycleNodes() is called.

unit tests are added
