### PR TITLE
add TooManyRequestError to sfxclient

### DIFF
--- a/sfxclient/multitokensink.go
+++ b/sfxclient/multitokensink.go
@@ -1,6 +1,7 @@
 package sfxclient
 
 import (
+	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -54,8 +55,9 @@ func getHTTPStatusCode(status *tokenStatus, err error) *tokenStatus {
 	if err == nil {
 		status.status = http.StatusOK
 	} else {
-		if obj, ok := err.(SFXAPIError); ok {
-			status.status = obj.StatusCode
+		var apiErr *SFXAPIError
+		if errors.As(err, &apiErr) {
+			status.status = apiErr.StatusCode
 		}
 	}
 	return status


### PR DESCRIPTION
Some information from SignalFx could be used to help the client to decide what to do on failure:

- 429 is only returned by the ingestion data points when a limit has been reached of metrics or event rates. 

- There is a Throttle-Type header returned with the 429 which indicates what the reason was for the 429 to be returned.

- There is a Retry-After header returned with the 429 which indicates the backoff time which should be used.