### PR TITLE
fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - export GO111MODULE=on
   - go mod download
   - golangci-lint run
-  - go test -v -covermode atomic -race -timeout 60s -cpu 4 -parallel 8 -coverprofile ./coverage.out $(go list ./...)
+  - go test -v -covermode atomic -race -timeout 70s -cpu 4 -parallel 8 -coverprofile ./coverage.out $(go list ./...)
   - "! go tool cover -func coverage.out | grep -v 100.0%"
 
 after_script:

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -103,10 +103,8 @@ type TooManyRequestError struct {
 }
 
 func (e TooManyRequestError) Error() string {
-	if e.ThrottleType == "" {
-		return fmt.Sprintf("too many requests, retry after %.3f seconds", e.RetryAfter.Seconds())
-	}
-	return fmt.Sprintf("too many %s requests, retry after %.3f seconds", e.ThrottleType, e.RetryAfter.Seconds())
+	return fmt.Sprintf("[%s] too many requests, retry after %.3f seconds",
+		e.ThrottleType, e.RetryAfter.Seconds())
 }
 
 type responseValidator func(respBody []byte) error
@@ -487,10 +485,6 @@ func sapmMarshal(v []*trace.Span) ([]byte, error) {
 }
 
 func parseRetryAfterHeader(v string) (time.Duration, error) {
-	if v == "" {
-		return 0, errors.New("empty header value")
-	}
-
 	// Retry-After: <http-date>
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
 	if t, err := http.ParseTime(v); err == nil {

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -102,16 +102,11 @@ type TooManyRequestError struct {
 	Err error
 }
 
-func (e *TooManyRequestError) Error() string {
+func (e TooManyRequestError) Error() string {
 	if e.ThrottleType == "" {
 		return fmt.Sprintf("too many requests, retry after %.3f seconds", e.RetryAfter.Seconds())
 	}
 	return fmt.Sprintf("too many %s requests, retry after %.3f seconds", e.ThrottleType, e.RetryAfter.Seconds())
-}
-
-// Unwrap returns the wrapped error.
-func (e *TooManyRequestError) Unwrap() error {
-	return e.Err
 }
 
 type responseValidator func(respBody []byte) error

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -109,6 +109,7 @@ func (e *TooManyRequestError) Error() string {
 	return fmt.Sprintf("too many %s requests, retry after %.3f seconds", e.ThrottleType, e.RetryAfter.Seconds())
 }
 
+// Unwrap returns the wrapped error.
 func (e *TooManyRequestError) Unwrap() error {
 	return e.Err
 }
@@ -498,15 +499,15 @@ func parseRetryAfterHeader(v string) (time.Duration, error) {
 	// Retry-After: <http-date>
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
 	if t, err := http.ParseTime(v); err == nil {
-		return t.Sub(time.Now()), nil
+		return time.Until(t), nil
 	}
 
 	// Retry-After: <delay-seconds>
-	if i, err := strconv.Atoi(v); err != nil {
+	i, err := strconv.Atoi(v)
+	if err != nil {
 		return 0, err
-	} else {
-		return time.Duration(i) * time.Second, nil
 	}
+	return time.Duration(i) * time.Second, nil
 }
 
 // NewHTTPSink creates a default NewHTTPSink using package level constants as

--- a/sfxclient/multitokensink.go
+++ b/sfxclient/multitokensink.go
@@ -1,7 +1,6 @@
 package sfxclient
 
 import (
-	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -55,9 +54,12 @@ func getHTTPStatusCode(status *tokenStatus, err error) *tokenStatus {
 	if err == nil {
 		status.status = http.StatusOK
 	} else {
-		var apiErr *SFXAPIError
-		if errors.As(err, &apiErr) {
-			status.status = apiErr.StatusCode
+		// refactor: use `errors.As` to simplify type assertion on error chain once we get rid of go 1.12 build.
+		if obj, ok := err.(*TooManyRequestError); ok {
+			err = obj.Err
+		}
+		if obj, ok := err.(*SFXAPIError); ok {
+			status.status = obj.StatusCode
 		}
 	}
 	return status

--- a/sfxclient/multitokensink_test.go
+++ b/sfxclient/multitokensink_test.go
@@ -104,6 +104,28 @@ func AddSpansGetSuccess(ctx context.Context, evs []*trace.Span) (err error) {
 	return
 }
 
+func TestGetHTTPStatusCode(t *testing.T) {
+	ts := &tokenStatus{}
+	Convey("should handle different type of errors", t, func() {
+		So(getHTTPStatusCode(ts, nil).status, ShouldEqual, http.StatusOK)
+
+		So(getHTTPStatusCode(ts, &SFXAPIError{
+			StatusCode:   http.StatusBadRequest,
+			ResponseBody: "",
+		}).status, ShouldEqual, http.StatusBadRequest)
+
+		err := &TooManyRequestError{
+			ThrottleType: "",
+			RetryAfter:   0,
+			Err: &SFXAPIError{
+				StatusCode:   http.StatusTooManyRequests,
+				ResponseBody: "",
+			},
+		}
+		So(getHTTPStatusCode(ts, err).status, ShouldEqual, http.StatusTooManyRequests)
+	})
+}
+
 func TestWorkerErrorHandlerDps(t *testing.T) {
 	Convey("An AsyncMultiTokeSink Worker Dps", t, func() {
 		Convey("should handle errors while emitting datapoints", func() {


### PR DESCRIPTION
this is a follow up PR of https://github.com/signalfx/golib/pull/179 which fix the build by:

- add test cases to make sure 100% coverage.
- refactor: re-arrange a few codes to make the lint-checker happy.
- refactor: remove usage of `errors.As` to pass go 1.12 build.

I've tested the build by setting up Travis CI in my forked repository and now https://travis-ci.org/github/beanliu/golib is green for sure.