### PR TITLE
Extend DefaultErrorHandler for AsyncMultiTokenSink

### DIFF
--- a/sfxclient/multitokensink_test.go
+++ b/sfxclient/multitokensink_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAsyncMultiTokenSinkStartup(t *testing.T) {
 	Convey("A default sink", t, func() {
-		So(NewAsyncMultiTokenSink(int64(1), int64(1), 5, 30, IngestEndpointV2, EventIngestEndpointV2, TraceIngestEndpointV1, DefaultUserAgent, newDefaultHTTPClient, DefaultErrorHandler, 0), ShouldNotBeNil)
+		So(NewAsyncMultiTokenSink(int64(1), int64(1), 5, 30, IngestEndpointV2, EventIngestEndpointV2, TraceIngestEndpointV1, DefaultUserAgent, newDefaultHTTPClient, DefaultAsyncErrorHandler, 0), ShouldNotBeNil)
 
 		Convey("should be able to startup successfully", func() {
 			So(NewAsyncMultiTokenSink(int64(1), int64(1), 5, 30, IngestEndpointV2, EventIngestEndpointV2, TraceIngestEndpointV1, DefaultUserAgent, newDefaultHTTPClient, nil, 0), ShouldNotBeNil)
@@ -265,7 +265,7 @@ func TestAsyncMultiTokenSinkShutdownDroppedDatapoints(t *testing.T) {
 				dps = append(dps, GoMetricsSource.Datapoints()...)
 			}
 			// intentionally slow down emission to test shutdown timeout
-			s.errorHandler = func(e error) error {
+			s.errorHandler = func(e error, token string, endpoint string) error {
 				time.Sleep(3 * time.Second)
 				return DefaultErrorHandler(e)
 			}
@@ -293,7 +293,7 @@ func TestAsyncMultiTokenSinkShutdownDroppedEvents(t *testing.T) {
 				evs = append(evs, GoEventSource.Events()...)
 			}
 			// intentionally slow down emission to test shutdown timeout
-			s.errorHandler = func(e error) error {
+			s.errorHandler = func(e error, token string, endpoint string) error {
 				time.Sleep(3 * time.Second)
 				return DefaultErrorHandler(e)
 			}
@@ -321,7 +321,7 @@ func TestAsyncMultiTokenSinkShutdownDroppedSpans(t *testing.T) {
 				evs = append(evs, GoSpanSource.Spans()...)
 			}
 			// intentionally slow down emission to test shutdown timeout
-			s.errorHandler = func(e error) error {
+			s.errorHandler = func(e error, token string, endpoint string) error {
 				time.Sleep(3 * time.Second)
 				return DefaultErrorHandler(e)
 			}


### PR DESCRIPTION
This change extends the existing DefaultErrorHandler by adding two extra
parameters, 'token' and 'endpoint'. This allows for custom error
handlers that can behave differently depending on the token or endpoint
involved in the error. In the AsyncMultiTokenSink case, this error
handler is only called when the underlying client can't successfully
call the ingestion endpoint after the configured number of retries.

An example of where this could be useful:
- The token for SignalFx ingestion is being throttled, so report the
error directly to cloudwatch so we can alert on it, with the token
and endpoint affected as dimensions for more targetted alerting.