### PR TITLE
Extend SFXAPIError to include endpoint

### DIFF
--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -82,6 +82,7 @@ type HTTPSink struct {
 type SFXAPIError struct {
 	StatusCode   int
 	ResponseBody string
+	Endpoint     string
 }
 
 func (se SFXAPIError) Error() string {
@@ -126,6 +127,7 @@ func (h *HTTPSink) handleResponse(resp *http.Response, respValidator responseVal
 		baseErr := &SFXAPIError{
 			StatusCode:   resp.StatusCode,
 			ResponseBody: string(respBody),
+			Endpoint:     resp.Request.URL.Path,
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests {


### PR DESCRIPTION
This change extends the existing SFXAPIError struct by adding two extra
fields 'token' and 'endpoint'. This allows for custom error
handlers that can behave differently depending on the token or endpoint
associated with the error. In the AsyncMultiTokenSink case, this error
handler is only called when the underlying client can't successfully
call the ingestion endpoint after the configured number of retries.

An example of where this could be useful:

The token for SignalFx ingestion is being throttled, so report the
error directly to cloudwatch so we can alert on it, with the token
and endpoint affected as dimensions for more targeted alerting.