### PR TITLE
Now populate a context with a spanfilter when turning zipkin into sapm

### DIFF
--- a/sfxclient/httpsink_test.go
+++ b/sfxclient/httpsink_test.go
@@ -15,13 +15,13 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-
 	sfxmodel "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/errors"
 	"github.com/signalfx/golib/v3/event"
 	"github.com/signalfx/golib/v3/log"
 	"github.com/signalfx/golib/v3/pointer"
+	"github.com/signalfx/golib/v3/sfxclient/spanfilter"
 	"github.com/signalfx/golib/v3/trace"
 	sapmpb "github.com/signalfx/sapm-proto/gen"
 	. "github.com/smartystreets/goconvey/convey"
@@ -566,7 +566,7 @@ func TestHTTPTraceSink(t *testing.T) {
 			retString := `{"invalid":{}, "valid":1}`
 			var blockResponse chan struct{}
 			var cancelCallback func()
-			seenSpans := []*trace.Span{}
+			var seenSpans []*trace.Span
 			handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				bodyBytes := bytes.Buffer{}
 				_, err := io.Copy(&bodyBytes, req.Body)
@@ -656,7 +656,7 @@ func TestSAPMMarshal(t *testing.T) {
 		}
 		marshalled, err := sapmMarshal(traces)
 		Convey("should marshal traces", func() {
-			So(err, ShouldBeNil)
+			So(spanfilter.IsInvalid(err), ShouldBeFalse)
 			psr := sapmpb.PostSpansRequest{}
 			err = proto.Unmarshal(marshalled, &psr)
 			Convey("which should unmarshal to SAPM PostSpansRequest", func() {

--- a/sfxclient/spanfilter/spanfilter.go
+++ b/sfxclient/spanfilter/spanfilter.go
@@ -15,6 +15,23 @@ type Map struct {
 	Invalid map[string][]string `json:"invalid,omitempty"`
 }
 
+const (
+	// InvalidSpanID has either the wrong length, or does not contain hex digits
+	InvalidSpanID = "invalidSpanID"
+	// InvalidTraceID has either the wrong length, or does not contain hex digits
+	InvalidTraceID = "invalidTraceID"
+	// ZipkinV2BinaryAnnotations are not allowed
+	ZipkinV2BinaryAnnotations
+	// NilServiceName when no localendpoint.name is provided
+	NilServiceName = "nilServiceName"
+	// ZeroTraceID when the traceid bytes are all zero
+	ZeroTraceID = "zeroTraceID"
+	// ZeroStartTime when the star time of the span is 0
+	ZeroStartTime = "zeroStartTime"
+	// TooManySpansInTrace when we find an abusive number of spans for a given traceID
+	TooManySpansInTrace = "tooManySpansInTrace"
+)
+
 var emptySpanFilter = &Map{}
 
 const (
@@ -81,7 +98,7 @@ const (
 )
 
 // WithSpanFilterContext gives you a request with the Map set
-func WithSpanFilterContext(ctx context.Context, sf *Map) context.Context {
+func WithSpanFilterContext(ctx context.Context, sf interface{}) context.Context {
 	return context.WithValue(ctx, spanFailures, sf)
 }
 


### PR DESCRIPTION
 - because the jaeger format can't express bad ids (except 0s) this is the best way to ship this information back
 - also annotate with a few other errors