### PR TITLE
Fix slice init bug causing initial nil entries

### DIFF
--- a/sfxclient/wrapper.go
+++ b/sfxclient/wrapper.go
@@ -18,7 +18,7 @@ func NewMultiCollector(collectors ...Collector) Collector {
 
 // Datapoints returns the datapoints from every collector.
 func (m MultiCollector) Datapoints() []*datapoint.Datapoint {
-	ret := make([]*datapoint.Datapoint, len(m))
+	ret := make([]*datapoint.Datapoint, 0)
 	for _, col := range m {
 		ret = append(ret, col.Datapoints()...)
 	}

--- a/sfxclient/wrapper_test.go
+++ b/sfxclient/wrapper_test.go
@@ -44,7 +44,7 @@ func ExampleNewMultiCollector() {
 	var a Collector
 	var b Collector
 	c := NewMultiCollector(a, b)
-	c.Datapoints()
+	So(len(c.Datapoints()), ShouldEqual, 0)
 }
 
 func ExampleCumulativeP() {


### PR DESCRIPTION
When you init a slice with a certain length and then use append,
it doesn't overwrite the initial entries created, it just adds more
entries after them.