### PR TITLE
Fix conversion bug for annotations to sapm logs, when not JSON

### DIFF
--- a/trace/translator/sfx_test.go
+++ b/trace/translator/sfx_test.go
@@ -294,6 +294,16 @@ var wantPostRequest = sapmpb.PostSpansRequest{
 								},
 							},
 						},
+						{
+							Timestamp: time.Date(2017, 01, 26, 21, 46, 31, 639875000, time.UTC),
+							Fields: []jaegerpb.KeyValue{
+								{
+									Key:   "annotation",
+									VType: jaegerpb.ValueType_STRING,
+									VStr:  "nothing",
+								},
+							},
+						},
 					},
 					Warnings: nil,
 				},


### PR DESCRIPTION
Apply same logic as in the ingest-protocols repository in the "v2AnnotationsToJaegerLogs" function. That needs now to be updated and not check for error.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>