### PR TITLE
fix test cases & travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - export GO111MODULE=on
   - go mod download
   - golangci-lint run -c .golangci.yml -v
-  - go test -covermode atomic -race -timeout 160s -cpu 4 -parallel 8 -coverprofile ./coverage.out $(go list ./...)
+  - go test -covermode atomic -race -timeout 160s -cpu 4 -coverprofile ./coverage.out $(go list ./... | grep -v /trace/format | grep -v /logkey)
   - "! go tool cover -func coverage.out | grep -v 100.0%"
 
 after_script:

--- a/distconf/zk_test.go
+++ b/distconf/zk_test.go
@@ -74,9 +74,12 @@ func TestZkConf(t *testing.T) {
 
 	DefaultLogger.Log("Doing write 3")
 	assert.NoError(t, z.Write("TestZkConf", nil))
-	select {
-	case res = <-signalChan:
-	case <-time.After(time.Second * 3):
+	for res != "TestZkConf" {
+		select {
+		case res = <-signalChan:
+		default:
+			runtime.Gosched()
+		}
 	}
 	assert.Equal(t, "TestZkConf", res)
 }

--- a/timekeeper/timekeeper_test.go
+++ b/timekeeper/timekeeper_test.go
@@ -22,20 +22,22 @@ func TestStop(t *testing.T) {
 }
 
 func TestAfterClose(t *testing.T) {
-	x := time.NewTimer(time.Millisecond * 100)
+	timer := time.Millisecond * 10
+	x := time.NewTimer(timer)
 	x.Stop()
 	select {
 	case <-x.C:
 		panic("NOPE")
-	case <-time.After(time.Millisecond * 200):
+	case <-time.After(timer * 2):
 	}
 }
 
 func TestRealTime(t *testing.T) {
 	r := RealTime{}
 	now := r.Now()
-	r.Sleep(time.Millisecond)
-	<-r.After(time.Millisecond)
-	<-r.NewTimer(time.Millisecond).Chan()
+	timer := time.Microsecond * 10
+	r.Sleep(timer)
+	<-r.After(timer)
+	<-r.NewTimer(timer).Chan()
 	assert.True(t, time.Now().After(now))
 }

--- a/web/starttime_test.go
+++ b/web/starttime_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestAddRequestTime(t *testing.T) {
 	now := time.Now()
-	time.Sleep(time.Millisecond)
+	time.Sleep(time.Nanosecond)
 	f := HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) {
 		rt := RequestTime(ctx)
 		assert.True(t, now.Before(rt))
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Nanosecond)
 		assert.True(t, time.Now().After(rt))
 	})
 	AddRequestTime(context.Background(), nil, nil, f)

--- a/zkplus/zkplus_test.go
+++ b/zkplus/zkplus_test.go
@@ -2,6 +2,7 @@ package zkplus
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -194,7 +195,7 @@ func TestBadConnection(t *testing.T) {
 	go func() {
 		conn = z.blockOnConn()
 	}()
-	time.Sleep(200 * time.Millisecond)
+	runtime.Gosched()
 	assert.Nil(t, conn)
 	z.Close()
 }


### PR DESCRIPTION
package golib/sfxclient currently is taking close to 30s for running
all test cases. This fix will reduce the testing time to ~4s.

Other packages have minor tune ups reducing testing time in order of
milliseconds.

There is no test case for golib/trace/format as it is auto-generated code
and golib/logkey as it contains only global variables. So removing both the
packages from go list output in travis.yml file.

golib doesn't use t.Parallel in any of the test suites and hence -parallel flag
is removed from go test arguments list