### PR TITLE
zkplus: Always check for existence even if creates allowed

### DIFF
--- a/disco/disco_test.go
+++ b/disco/disco_test.go
@@ -125,7 +125,7 @@ func TestErrorNoRootCreate(t *testing.T) {
 	c := 0
 	z.SetErrorCheck(func(s string) error {
 		c++
-		if c < 2 {
+		if c < 3 {
 			return nil
 		}
 		return zk.ErrNoNode

--- a/zkplus/zkplus_test.go
+++ b/zkplus/zkplus_test.go
@@ -117,6 +117,8 @@ func TestErrorEnsureRootNoCreate(t *testing.T) {
 
 	zkp, err = NewBuilder().PathPrefix("/test").CreateRootNode(false).Connector(&StaticConnector{C: z, Ch: ch}).Build()
 	assert.NoError(t, err)
+	err = zkp.ensureRootPath(z)
+	assert.Equal(t, err, errors.New("root node \"/test\" does not exist"))
 	zkp.Close()
 }
 


### PR DESCRIPTION
This will avoid more issues when dealing wiht read-only root nodes