### PR TITLE
zkconn should honor memory zk server logger type

### DIFF
--- a/zkplus/zktest/zktest_test.go
+++ b/zkplus/zktest/zktest_test.go
@@ -418,3 +418,12 @@ func testChildrenWNotHere(t *testing.T, z ZkConnSupported, z2 ZkConnSupported, _
 	case <-time.After(time.Microsecond):
 	}
 }
+
+func TestDiscardLoggerSetup(t *testing.T) {
+	zkConn := &ZkConn{}
+	nextID := int64(0)
+	zkConn.setZkConnLogger(log.Discard, &nextID)
+	assert.Equal(t, zkConn.Logger, log.Discard)
+	zkConn.setZkConnLogger(log.DefaultLogger, &nextID)
+	assert.NotEqual(t, zkConn.Logger, log.Discard)
+}


### PR DESCRIPTION
current zkconn logger is auto set to new context logger which is
incorrect as there are cases when the user could have set the memory zk
server logger to be of discard type