### PR TITLE
sfxclient/httpsink: use hex encoded string representation for loggabl…

### DIFF
--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -160,7 +161,7 @@ func getShaValue(values []string) string {
 	for _, v := range values {
 		h.Write([]byte(v))
 	}
-	return string(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // loggableHeaders returns headers that are only allowed to be logged. For instance "X-Sf-Token" should not be logged so


### PR DESCRIPTION
…e headers

if sha1 representation bytes is directly converted to string the output is garbage during
logging. Instead use go built-in hex package EncodeToString() api