### PR TITLE
Fix golangci-lint issues by upgrading + fixing new stuff

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.46.0
           # Optional: golangci-lint command line arguments.
           args: '--config=.golangci.yml -v'
 
@@ -27,7 +27,7 @@ jobs:
           # skip-go-installation: true
 
           # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
+          skip-pkg-cache: true
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ run:
   skip-files:
     - ".*\\.pb\\.go"
     - ".*\\.gen\\.go"
+    - ".*_easyjson\\.go"
   # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit
   # automatic updating of go.mod described above. Instead, it fails when any changes
@@ -150,6 +151,7 @@ linters-settings:
     threshold: 100
 
 linters:
+  disable-all: true
   enable: # please use alphabetical order when enabling any linters
     - asciicheck
     - bodyclose
@@ -162,7 +164,6 @@ linters:
     - errname
     - exportloopref
     - forbidigo
-    - forcetypeassert
     - gci
     - gocognit
     - goconst
@@ -194,31 +195,11 @@ linters:
     - testpackage
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
-  enable-all: true
-  disable:
-    - lll
-    - paralleltest # this has lots of test cases that needs to be added as parallel and some of them have race condition so disabling after some effort
-    - gochecknoglobals
-    - exhaustive
-    # TODO: need to enable this two low priority for better coding guidelines in terms of space between condition
-    - wsl
-    - godot
-    - gomnd # we cannot enable this as there are lots of magic numbers
-    - nestif # cannot enable this given the way the code structure is organized for unit testing
-    - nlreturn
-    - nolintlint
-    - tagliatelle # cannot be enabled as it's asking to modify `json` which is not possible
-    - promlinter # we do not care above prometheus linter for metrics
-    - gomoddirectives # needs to be disabled as we need replacement for jaeger & redis
-    - scopelint # deprecated and hence disabled it
-    - interfacer # deprecated and hence disabled
-    - wrapcheck # Checks that errors returned from external packages are wrapped
   fast: true
 
 # output configuration options

--- a/distconf/mem.go
+++ b/distconf/mem.go
@@ -36,8 +36,7 @@ func (m *memConfig) Write(key string, value []byte) error {
 func (m *memConfig) Watch(key string, callback backingCallbackFunction) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_, existing := m.watches[key]
-	if !existing {
+	if _, existing := m.watches[key]; !existing {
 		m.watches[key] = []backingCallbackFunction{}
 	}
 	m.watches[key] = append(m.watches[key], callback)

--- a/explorable/explorable.go
+++ b/explorable/explorable.go
@@ -69,8 +69,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 		childTable += "</table>\n"
 	}
-	s :=
-		fmt.Sprintf(`
+	s := fmt.Sprintf(`
 <!DOCTYPE html>
 <html>
 	<head>

--- a/log/ratelimit.go
+++ b/log/ratelimit.go
@@ -26,8 +26,7 @@ func (r *RateLimitedLogger) now() time.Time {
 
 // Log kvs to the wrapped Logger if the limit hasn't been reached
 func (r *RateLimitedLogger) Log(kvs ...interface{}) {
-	now := r.now()
-	if r.EventCounter.Event(now) > r.Limit {
+	if r.EventCounter.Event(r.now()) > r.Limit {
 		if r.LimitLogger != nil {
 			// Note: Log here messes up "caller" :/
 			r.LimitLogger.Log(kvs...)

--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -178,8 +178,7 @@ func loggableHeaders(headers map[string][]string) (rv map[string][]string) {
 	return rv
 }
 
-func (h *HTTPSink) doBottom(ctx context.Context, f func() (io.Reader, bool, error), contentType, endpoint string,
-	respValidator responseValidator) error {
+func (h *HTTPSink) doBottom(ctx context.Context, f func() (io.Reader, bool, error), contentType, endpoint string, respValidator responseValidator) error {
 	if ctx.Err() != nil {
 		return errors.Annotate(ctx.Err(), "context already closed")
 	}

--- a/sfxclient/httpsink_test.go
+++ b/sfxclient/httpsink_test.go
@@ -736,7 +736,7 @@ func TestSetHeaders(t *testing.T) {
 	Convey("test setTokenHeader", t, func() {
 		h := &HTTPSink{AuthToken: "foo", UserAgent: "agent"}
 		req := httptest.NewRequest(http.MethodPost, "/v2/datapoint", nil)
-		// nolint:golint,staticcheck
+		// nolint:golint,staticcheck,revive
 		ctx := context.WithValue(context.Background(), TokenHeaderName, "bar")
 		h.setTokenHeader(ctx, req)
 		So(req.Header.Get(TokenHeaderName), ShouldEqual, "bar")

--- a/trace/translator/sfx_test.go
+++ b/trace/translator/sfx_test.go
@@ -363,7 +363,6 @@ var wantPostRequest = sapmpb.PostSpansRequest{
 					Logs: []jaegerpb.Log{},
 				},
 				{
-
 					TraceID:       jaegerpb.TraceID{Low: 15174485909104433727},
 					SpanID:        jaegerpb.SpanID(47532398882098234),
 					OperationName: strings.ToLower(http.MethodPost),
@@ -392,7 +391,6 @@ var wantPostRequest = sapmpb.PostSpansRequest{
 					Logs: []jaegerpb.Log{},
 				},
 				{
-
 					TraceID:       jaegerpb.TraceID{Low: 16327407413711280703},
 					SpanID:        jaegerpb.SpanID(52035998509468730),
 					OperationName: "post",


### PR DESCRIPTION
Apparently the version we were on had a bug with the typecheck linter.