### PR TITLE
Deprecate all packages

### DIFF
--- a/clientcfg/client.go
+++ b/clientcfg/client.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package clientcfg
 
 import (

--- a/datapoint/cast.go
+++ b/datapoint/cast.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package datapoint
 
 import (

--- a/datapoint/dplocal/local.go
+++ b/datapoint/dplocal/local.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package dplocal
 
 import (

--- a/datapoint/dpsink/counter.go
+++ b/datapoint/dpsink/counter.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package dpsink
 
 import (

--- a/datapoint/dptest/basicsink.go
+++ b/datapoint/dptest/basicsink.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package dptest
 
 import (

--- a/dataunit/dataunit.go
+++ b/dataunit/dataunit.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package dataunit
 
 // Size represents a measurement of data and can return that measurement

--- a/disco/disco.go
+++ b/disco/disco.go
@@ -1,3 +1,5 @@
+// Deprecated: this package is no longer supported.
+//
 //nolint:gocritic
 package disco
 

--- a/distconf/bool.go
+++ b/distconf/bool.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package distconf
 
 import (

--- a/env/env.go
+++ b/env/env.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package env
 
 import (

--- a/errors/analyze.go
+++ b/errors/analyze.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package errors
 
 import (

--- a/event/event.go
+++ b/event/event.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package event
 
 import (

--- a/eventcounter/eventcounter.go
+++ b/eventcounter/eventcounter.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package eventcounter
 
 import (

--- a/explorable/explorable.go
+++ b/explorable/explorable.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package explorable
 
 import (

--- a/expvar2/handler.go
+++ b/expvar2/handler.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package expvar2
 
 import (

--- a/go-metrics/exporter.go
+++ b/go-metrics/exporter.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package go_metrics
 
 import (

--- a/gojavahash/gojavahash.go
+++ b/gojavahash/gojavahash.go
@@ -1,6 +1,7 @@
 // Package gojavahash implements a ServerSelector for gomemcache that provides
 // hashing that's compatible with SpyMemcached's native (e.g. java) hashing.
 // This is based very closely on the excellent https://github.com/thatguystone/gomcketama
+// Deprecated: this package is no longer supported.
 package gojavahash
 
 import (

--- a/httpdebug/pprof14.go
+++ b/httpdebug/pprof14.go
@@ -1,5 +1,7 @@
+//go:build !go1.5
 // +build !go1.5
 
+// Deprecated: this package is no longer supported.
 package httpdebug
 
 import (

--- a/log/channel.go
+++ b/log/channel.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package log
 
 // ChannelLogger creates a logger that sends log messages to a channel.  It's useful for testing and buffering

--- a/logkey/keys.go
+++ b/logkey/keys.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package logkey
 
 import "github.com/signalfx/golib/v3/log"

--- a/logsink/logsink.go
+++ b/logsink/logsink.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package logsink
 
 import (

--- a/maestro/load.go
+++ b/maestro/load.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package maestro
 
 import (

--- a/metadata/aws/ec2metadata/ec2.go
+++ b/metadata/aws/ec2metadata/ec2.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package ec2metadata
 
 import (

--- a/metadata/hostmetadata/host.go
+++ b/metadata/hostmetadata/host.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package hostmetadata
 
 import (

--- a/nettest/tcpport.go
+++ b/nettest/tcpport.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package nettest
 
 import (

--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package pointer
 
 import (

--- a/reportsha/reportsha.go
+++ b/reportsha/reportsha.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package reportsha
 
 import (

--- a/safeexec/safeexec.go
+++ b/safeexec/safeexec.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package safeexec
 
 import (

--- a/sfxclient/cumulativebucket.go
+++ b/sfxclient/cumulativebucket.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package sfxclient
 
 import (

--- a/sfxclient/spanfilter/spanfilter.go
+++ b/sfxclient/spanfilter/spanfilter.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package spanfilter
 
 import (

--- a/sfxtest/sfxtest.go
+++ b/sfxtest/sfxtest.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package sfxtest
 
 import "sync"

--- a/timekeeper/timekeeper.go
+++ b/timekeeper/timekeeper.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package timekeeper
 
 import "time"

--- a/timekeeper/timekeepertest/timekeepertest.go
+++ b/timekeeper/timekeepertest/timekeepertest.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package timekeepertest
 
 import (

--- a/trace/format/format.go
+++ b/trace/format/format.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package traceformat
 
 import "github.com/signalfx/golib/v3/trace"

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package trace
 
 import (

--- a/trace/translator/batcher.go
+++ b/trace/translator/batcher.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: this package is no longer supported.
 package translator
 
 import (

--- a/web/bucketreqcounter.go
+++ b/web/bucketreqcounter.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package web
 
 import (

--- a/zkplus/builder.go
+++ b/zkplus/builder.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package zkplus
 
 import (

--- a/zkplus/zktest/zktest.go
+++ b/zkplus/zktest/zktest.go
@@ -1,3 +1,4 @@
+// Deprecated: this package is no longer supported.
 package zktest
 
 import (


### PR DESCRIPTION
This PR deprecates all packages of this repository. This places this repository in a deprecated state where no new code will be added. Instead, developers can copy code out of this repository for use in the library or migrate away.