### PR TITLE
Allow dot () character in dimensions name (Breaking Change)

### DIFF
--- a/sfxclient/httpsink.go
+++ b/sfxclient/httpsink.go
@@ -326,7 +326,7 @@ func filterSignalfxKey(str string) string {
 }
 
 func runeFilterMap(r rune) rune {
-	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' || r == '-' {
+	if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '_' || r == '-' || r == '.' {
 		return r
 	}
 	return '_'

--- a/sfxclient/httpsink_test.go
+++ b/sfxclient/httpsink_test.go
@@ -262,11 +262,17 @@ func TestHTTPDatapointSink(t *testing.T) {
 				So(s.AddDatapoints(ctx, dps), ShouldBeNil)
 				So(len(seenBodyPoints.Datapoints[0].Dimensions), ShouldEqual, 0)
 			})
-			Convey("invalid rune filtering should happen", func() {
+			Convey("dot character should be preserved in dimension keys", func() {
 				dps[0].Dimensions = map[string]string{"hi.bob": "hi"}
 				dps = dps[0:1]
 				So(s.AddDatapoints(ctx, dps), ShouldBeNil)
-				So(seenBodyPoints.Datapoints[0].Dimensions[0].Key, ShouldEqual, "hi_bob")
+				So(seenBodyPoints.Datapoints[0].Dimensions[0].Key, ShouldEqual, "hi.bob")
+			})
+			Convey("invalid rune filtering should still happen for other characters", func() {
+				dps[0].Dimensions = map[string]string{"hi@bob#test": "hi"}
+				dps = dps[0:1]
+				So(s.AddDatapoints(ctx, dps), ShouldBeNil)
+				So(seenBodyPoints.Datapoints[0].Dimensions[0].Key, ShouldEqual, "hi_bob_test")
 			})
 			Convey("Invalid datapoints should panic", func() {
 				dps[0].MetricType = datapoint.MetricType(1001)
@@ -496,11 +502,17 @@ func TestHTTPEventSink(t *testing.T) {
 				So(s.AddEvents(ctx, events), ShouldBeNil)
 				So(len(seenBodyEvents.Events[0].Dimensions), ShouldEqual, 0)
 			})
-			Convey("invalid rune filtering should happen", func() {
+			Convey("dot character should be preserved in dimension keys", func() {
 				events[0].Dimensions = map[string]string{"hi.bob": "hi"}
 				events = events[0:1]
 				So(s.AddEvents(ctx, events), ShouldBeNil)
-				So(seenBodyEvents.Events[0].Dimensions[0].Key, ShouldEqual, "hi_bob")
+				So(seenBodyEvents.Events[0].Dimensions[0].Key, ShouldEqual, "hi.bob")
+			})
+			Convey("invalid rune filtering should still happen for other characters", func() {
+				events[0].Dimensions = map[string]string{"hi@bob#test": "hi"}
+				events = events[0:1]
+				So(s.AddEvents(ctx, events), ShouldBeNil)
+				So(seenBodyEvents.Events[0].Dimensions[0].Key, ShouldEqual, "hi_bob_test")
 			})
 			Convey("Invalid events should panic", func() {
 				events[0].Category = event.Category(999999)


### PR DESCRIPTION
Note, this is needed to unblock moving to OTel semantics and fix ingest dashboards 
Historically, `.` was not allowed in our backend and this is no longer the case

# Breaking Changes

### Dimension Key Filtering - Dot Character Now Allowed

**BREAKING CHANGE**: The `runeFilterMap` function in `sfxclient/httpsink.go` has been updated to allow the dot (`.`) character in dimension keys.

#### What Changed

Previously, dimension keys containing the dot character (`.`) would have those dots automatically replaced with underscores (`_`). For example:
- `"service.endpoint"` would become `"service_endpoint"`

With this change, the dot character is now preserved in dimension keys:
- `"service.endpoint"` remains `"service.endpoint"`

#### Impact

**If you are currently sending dimensions with dot characters (`.`)**, those dimensions will now be sent to SignalFx with the dots preserved instead of being converted to underscores.

This could affect:
1. **Existing metrics and dashboards**: If your dashboards or alerts reference dimension keys with underscores that were originally sent with dots, they may stop matching after upgrading.
2. **Historical data**: You may see a split in your data where older data uses underscores and newer data uses dots.
3. **Queries and filters**: Any queries that rely on the underscore-replaced dimension keys will need to be updated.

#### Allowed Characters

After this change, the following characters are allowed in dimension keys:
- Letters (a-z, A-Z)
- Digits (0-9)
- Underscore (`_`)
- Hyphen/Dash (`-`)
- **Dot (`.`)** ← **NEW**

All other characters will still be replaced with underscores.

